### PR TITLE
fix: add `data_dir` back to `GadgetConfiguration`

### DIFF
--- a/blueprint-manager/src/config.rs
+++ b/blueprint-manager/src/config.rs
@@ -14,8 +14,8 @@ pub struct BlueprintManagerConfig {
     #[structopt(short = "k", long)]
     pub keystore_uri: String,
     /// The directory in which all gadgets will store their data
-    #[structopt(long, short = "d", parse(from_os_str))]
-    pub data_dir: Option<PathBuf>,
+    #[structopt(long, short = "d", parse(from_os_str), default_value = "./data")]
+    pub data_dir: PathBuf,
     /// The verbosity level, can be used multiple times
     #[structopt(long, short = "v", parse(from_occurrences))]
     pub verbose: i32,

--- a/blueprint-manager/src/executor/mod.rs
+++ b/blueprint-manager/src/executor/mod.rs
@@ -147,14 +147,13 @@ pub async fn run_blueprint_manager<F: SendFuture<'static, ()>>(
     let _span = span.enter();
     info!("Starting blueprint manager ... waiting for start signal ...");
 
-    if let Some(data_dir) = &blueprint_manager_config.data_dir {
-        if !data_dir.exists() {
-            info!(
-                "Data directory does not exist, creating it at `{}`",
-                data_dir.display()
-            );
-            std::fs::create_dir_all(data_dir)?;
-        }
+    let data_dir = &blueprint_manager_config.data_dir;
+    if !data_dir.exists() {
+        info!(
+            "Data directory does not exist, creating it at `{}`",
+            data_dir.display()
+        );
+        std::fs::create_dir_all(data_dir)?;
     }
 
     let (tangle_key, ecdsa_key) = {

--- a/blueprint-manager/src/main.rs
+++ b/blueprint-manager/src/main.rs
@@ -12,9 +12,7 @@ async fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
     let mut blueprint_manager_config = BlueprintManagerConfig::from_args();
 
-    if let Some(data_dir) = blueprint_manager_config.data_dir.as_mut() {
-        *data_dir = std::path::absolute(&data_dir)?;
-    }
+    blueprint_manager_config.data_dir = std::path::absolute(&blueprint_manager_config.data_dir)?;
 
     entry::setup_blueprint_manager_logger(
         blueprint_manager_config.verbose,

--- a/blueprint-manager/src/sources/mod.rs
+++ b/blueprint-manager/src/sources/mod.rs
@@ -67,13 +67,12 @@ pub async fn handle<'a>(
             ("SERVICE_ID".to_string(), format!("{}", service_id)),
         ];
 
-        if let Some(base) = &blueprint_manager_opts.data_dir {
-            let data_dir = base.join(format!("blueprint-{blueprint_id}-{sub_service_str}"));
-            env_vars.push((
-                "DATA_DIR".to_string(),
-                data_dir.to_string_lossy().into_owned(),
-            ))
-        }
+        let base_data_dir = &blueprint_manager_opts.data_dir;
+        let data_dir = base_data_dir.join(format!("blueprint-{blueprint_id}-{sub_service_str}"));
+        env_vars.push((
+            "DATA_DIR".to_string(),
+            data_dir.to_string_lossy().into_owned(),
+        ));
 
         // Ensure our child process inherits the current processes' environment vars
         env_vars.extend(std::env::vars());

--- a/blueprint-test-utils/src/lib.rs
+++ b/blueprint-test-utils/src/lib.rs
@@ -58,17 +58,19 @@ pub struct PerTestNodeInput<T> {
 pub async fn run_test_blueprint_manager<T: Send + Clone + 'static>(
     input: PerTestNodeInput<T>,
 ) -> BlueprintManagerHandle {
+    let name_lower = NAME_IDS[input.instance_id as usize].to_lowercase();
+
     let tmp_store = Uuid::new_v4().to_string();
-    let keystore_uri = PathBuf::from(format!(
-        "./target/keystores/{}/{tmp_store}/",
-        NAME_IDS[input.instance_id as usize].to_lowercase()
-    ));
+    let keystore_uri = PathBuf::from(format!("./target/keystores/{name_lower}/{tmp_store}/",));
 
     assert!(
         !keystore_uri.exists(),
         "Keystore URI cannot exist: {}",
         keystore_uri.display()
     );
+
+    let data_dir = std::path::absolute(format!("./target/data/{name_lower}"))
+        .expect("Failed to get current directory");
 
     let keystore_uri_normalized =
         std::path::absolute(keystore_uri).expect("Failed to resolve keystore URI");
@@ -85,7 +87,7 @@ pub async fn run_test_blueprint_manager<T: Send + Clone + 'static>(
 
     let blueprint_manager_config = BlueprintManagerConfig {
         gadget_config: None,
-        data_dir: None,
+        data_dir,
         keystore_uri: keystore_uri_str.clone(),
         verbose: input.verbose,
         pretty: input.pretty,

--- a/sdk/src/config.rs
+++ b/sdk/src/config.rs
@@ -10,6 +10,7 @@ use eigensdk::crypto_bls;
 use gadget_io::SupportedChains;
 use libp2p::Multiaddr;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 use structopt::StructOpt;
 use url::Url;
 
@@ -80,6 +81,10 @@ pub struct GadgetConfiguration<RwLock: lock_api::RawRwLock> {
     /// * In Memory: `file::memory:` or `:memory:`
     /// * Filesystem: `file:/path/to/keystore` or `file:///path/to/keystore`
     pub keystore_uri: String,
+    /// Data directory exclusively for this gadget
+    ///
+    /// This will be `None` if the blueprint manager was not provided a base directory.
+    pub data_dir: Option<PathBuf>,
     /// Blueprint ID for this gadget.
     pub blueprint_id: u64,
     /// Service ID for this gadget.
@@ -128,6 +133,7 @@ impl<RwLock: lock_api::RawRwLock> Clone for GadgetConfiguration<RwLock> {
         Self {
             rpc_endpoint: self.rpc_endpoint.clone(),
             keystore_uri: self.keystore_uri.clone(),
+            data_dir: self.data_dir.clone(),
             blueprint_id: self.blueprint_id,
             service_id: self.service_id,
             is_registration: self.is_registration,
@@ -147,6 +153,7 @@ impl<RwLock: lock_api::RawRwLock> Default for GadgetConfiguration<RwLock> {
         Self {
             rpc_endpoint: "http://localhost:9944".to_string(),
             keystore_uri: "file::memory:".to_string(),
+            data_dir: None,
             blueprint_id: 0,
             service_id: Some(0),
             is_registration: false,
@@ -327,6 +334,7 @@ fn load_inner<RwLock: lock_api::RawRwLock>(
         span,
         rpc_endpoint: url.to_string(),
         keystore_uri,
+        data_dir: std::env::var("DATA_DIR").ok().map(PathBuf::from),
         blueprint_id,
         // If the registration mode is on, we don't need the service ID
         service_id: if is_registration {


### PR DESCRIPTION
It was (mistakenly?) removed in #333. Went ahead and added a default path for blueprint manager as well.