### PR TITLE
fix(sdk)!: downgrade substrate dependencies for now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,7 +1752,7 @@ dependencies = [
  "reqwest 0.12.8",
  "serde",
  "sha2 0.10.8",
- "sp-core 34.0.0",
+ "sp-core",
  "structopt",
  "tangle-subxt",
  "tokio",
@@ -1797,9 +1797,9 @@ dependencies = [
  "log",
  "parking_lot",
  "serde_json",
- "sp-application-crypto 38.0.0",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-io",
  "subxt",
  "testcontainers",
  "tokio",
@@ -4512,9 +4512,9 @@ dependencies = [
  "scale-info",
  "serde",
  "serde-wasm-bindgen",
- "sp-application-crypto 38.0.0",
- "sp-core 34.0.0",
- "sp-keystore 0.40.0",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-keystore",
  "structopt",
  "thiserror",
  "tokio",
@@ -4573,8 +4573,8 @@ dependencies = [
  "schnorrkel",
  "serde",
  "serde_json",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-core",
+ "sp-io",
  "sqlx",
  "structopt",
  "subxt",
@@ -5716,7 +5716,7 @@ dependencies = [
  "lock_api",
  "parking_lot",
  "serde_json",
- "sp-core 34.0.0",
+ "sp-core",
  "structopt",
  "subxt-signer",
  "tokio",
@@ -5757,7 +5757,7 @@ dependencies = [
  "lock_api",
  "parking_lot",
  "serde_json",
- "sp-core 34.0.0",
+ "sp-core",
  "structopt",
  "subxt-signer",
  "tokio",
@@ -9671,16 +9671,16 @@ dependencies = [
 
 [[package]]
 name = "sc-keystore"
-version = "33.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebd4b5b5713006117641c049cb082e8a439dd6ac5e7b171e5cef5ce1c9f8af8"
+checksum = "3ef7283da5d643ef89ed094e1b23451ec70386a9474d337cdaa0ef81870bb2d4"
 dependencies = [
  "array-bytes",
  "parking_lot",
  "serde_json",
- "sp-application-crypto 38.0.0",
- "sp-core 34.0.0",
- "sp-keystore 0.40.0",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-keystore",
  "thiserror",
 ]
 
@@ -10536,22 +10536,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
+ "sp-core",
+ "sp-io",
  "sp-std",
-]
-
-[[package]]
-name = "sp-application-crypto"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8133012faa5f75b2f0b1619d9f720c1424ac477152c143e5f7dbde2fe1a958"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
 ]
 
 [[package]]
@@ -10604,59 +10591,12 @@ dependencies = [
  "serde",
  "sp-crypto-hashing",
  "sp-debug-derive",
- "sp-externalities 0.27.0",
- "sp-runtime-interface 26.0.0",
+ "sp-externalities",
+ "sp-runtime-interface",
  "sp-std",
- "sp-storage 20.0.0",
+ "sp-storage",
  "ss58-registry",
- "substrate-bip39 0.5.0",
- "thiserror",
- "tracing",
- "w3f-bls",
- "zeroize",
-]
-
-[[package]]
-name = "sp-core"
-version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c961a5e33fb2962fa775c044ceba43df9c6f917e2c35d63bfe23738468fa76a7"
-dependencies = [
- "array-bytes",
- "bitflags 1.3.2",
- "blake2",
- "bounded-collections",
- "bs58",
- "dyn-clonable",
- "ed25519-zebra 4.0.3",
- "futures",
- "hash-db",
- "hash256-std-hasher",
- "impl-serde",
- "itertools 0.11.0",
- "k256",
- "libsecp256k1",
- "log",
- "merlin",
- "parity-bip39",
- "parity-scale-codec",
- "parking_lot",
- "paste",
- "primitive-types",
- "rand",
- "scale-info",
- "schnorrkel",
- "secp256k1",
- "secrecy",
- "serde",
- "sp-crypto-hashing",
- "sp-debug-derive",
- "sp-externalities 0.29.0",
- "sp-runtime-interface 28.0.0",
- "sp-std",
- "sp-storage 21.0.0",
- "ss58-registry",
- "substrate-bip39 0.6.0",
+ "substrate-bip39",
  "thiserror",
  "tracing",
  "w3f-bls",
@@ -10697,18 +10637,7 @@ dependencies = [
  "environmental",
  "parity-scale-codec",
  "sp-std",
- "sp-storage 20.0.0",
-]
-
-[[package]]
-name = "sp-externalities"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a904407d61cb94228c71b55a9d3708e9d6558991f9e83bd42bd91df37a159d30"
-dependencies = [
- "environmental",
- "parity-scale-codec",
- "sp-storage 21.0.0",
+ "sp-storage",
 ]
 
 [[package]]
@@ -10725,42 +10654,15 @@ dependencies = [
  "polkavm-derive 0.9.1",
  "rustversion",
  "secp256k1",
- "sp-core 31.0.0",
+ "sp-core",
  "sp-crypto-hashing",
- "sp-externalities 0.27.0",
- "sp-keystore 0.37.0",
- "sp-runtime-interface 26.0.0",
- "sp-state-machine 0.38.0",
+ "sp-externalities",
+ "sp-keystore",
+ "sp-runtime-interface",
+ "sp-state-machine",
  "sp-std",
- "sp-tracing 16.0.0",
- "sp-trie 32.0.0",
- "tracing",
- "tracing-core",
-]
-
-[[package]]
-name = "sp-io"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ef7eb561bb4839cc8424ce58c5ea236cbcca83f26fcc0426d8decfe8aa97d4"
-dependencies = [
- "bytes",
- "docify",
- "ed25519-dalek",
- "libsecp256k1",
- "log",
- "parity-scale-codec",
- "polkavm-derive 0.9.1",
- "rustversion",
- "secp256k1",
- "sp-core 34.0.0",
- "sp-crypto-hashing",
- "sp-externalities 0.29.0",
- "sp-keystore 0.40.0",
- "sp-runtime-interface 28.0.0",
- "sp-state-machine 0.43.0",
- "sp-tracing 17.0.1",
- "sp-trie 37.0.0",
+ "sp-tracing",
+ "sp-trie",
  "tracing",
  "tracing-core",
 ]
@@ -10773,20 +10675,8 @@ checksum = "bdbab8b61bd61d5f8625a0c75753b5d5a23be55d3445419acd42caf59cf6236b"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
- "sp-core 31.0.0",
- "sp-externalities 0.27.0",
-]
-
-[[package]]
-name = "sp-keystore"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0248b4d784cb4a01472276928977121fa39d977a5bb24793b6b15e64b046df42"
-dependencies = [
- "parity-scale-codec",
- "parking_lot",
- "sp-core 34.0.0",
- "sp-externalities 0.29.0",
+ "sp-core",
+ "sp-externalities",
 ]
 
 [[package]]
@@ -10817,10 +10707,10 @@ dependencies = [
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto 33.0.0",
+ "sp-application-crypto",
  "sp-arithmetic",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
+ "sp-core",
+ "sp-io",
  "sp-std",
  "sp-weights",
 ]
@@ -10836,32 +10726,12 @@ dependencies = [
  "parity-scale-codec",
  "polkavm-derive 0.8.0",
  "primitive-types",
- "sp-externalities 0.27.0",
+ "sp-externalities",
  "sp-runtime-interface-proc-macro",
  "sp-std",
- "sp-storage 20.0.0",
- "sp-tracing 16.0.0",
- "sp-wasm-interface 20.0.0",
- "static_assertions",
-]
-
-[[package]]
-name = "sp-runtime-interface"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985eb981f40c689c6a0012c937b68ed58dabb4341d06f2dfe4dfd5ed72fa4017"
-dependencies = [
- "bytes",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "polkavm-derive 0.9.1",
- "primitive-types",
- "sp-externalities 0.29.0",
- "sp-runtime-interface-proc-macro",
- "sp-std",
- "sp-storage 21.0.0",
- "sp-tracing 17.0.1",
- "sp-wasm-interface 21.0.1",
+ "sp-storage",
+ "sp-tracing",
+ "sp-wasm-interface",
  "static_assertions",
 ]
 
@@ -10891,35 +10761,14 @@ dependencies = [
  "parking_lot",
  "rand",
  "smallvec",
- "sp-core 31.0.0",
- "sp-externalities 0.27.0",
+ "sp-core",
+ "sp-externalities",
  "sp-panic-handler",
  "sp-std",
- "sp-trie 32.0.0",
+ "sp-trie",
  "thiserror",
  "tracing",
- "trie-db 0.28.0",
-]
-
-[[package]]
-name = "sp-state-machine"
-version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930104d6ae882626e8880d9b1578da9300655d337a3ffb45e130c608b6c89660"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
- "parking_lot",
- "rand",
- "smallvec",
- "sp-core 34.0.0",
- "sp-externalities 0.29.0",
- "sp-panic-handler",
- "sp-trie 37.0.0",
- "thiserror",
- "tracing",
- "trie-db 0.29.1",
+ "trie-db",
 ]
 
 [[package]]
@@ -10943,19 +10792,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-storage"
-version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c82989b3a4979a7e1ad848aad9f5d0b4388f1f454cc131766526601ab9e8f8"
-dependencies = [
- "impl-serde",
- "parity-scale-codec",
- "ref-cast",
- "serde",
- "sp-debug-derive",
-]
-
-[[package]]
 name = "sp-tracing"
 version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10966,18 +10802,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-subscriber 0.2.25",
-]
-
-[[package]]
-name = "sp-tracing"
-version = "17.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf641a1d17268c8fcfdb8e0fa51a79c2d4222f4cfda5f3944dbdbc384dced8d5"
-dependencies = [
- "parity-scale-codec",
- "tracing",
- "tracing-core",
- "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -10996,36 +10820,12 @@ dependencies = [
  "rand",
  "scale-info",
  "schnellru",
- "sp-core 31.0.0",
- "sp-externalities 0.27.0",
+ "sp-core",
+ "sp-externalities",
  "sp-std",
  "thiserror",
  "tracing",
- "trie-db 0.28.0",
- "trie-root",
-]
-
-[[package]]
-name = "sp-trie"
-version = "37.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6282aef9f4b6ecd95a67a45bcdb67a71f4a4155c09a53c10add4ffe823db18cd"
-dependencies = [
- "ahash 0.8.11",
- "hash-db",
- "lazy_static",
- "memory-db",
- "nohash-hasher",
- "parity-scale-codec",
- "parking_lot",
- "rand",
- "scale-info",
- "schnellru",
- "sp-core 34.0.0",
- "sp-externalities 0.29.0",
- "thiserror",
- "tracing",
- "trie-db 0.29.1",
+ "trie-db",
  "trie-root",
 ]
 
@@ -11041,18 +10841,6 @@ dependencies = [
  "parity-scale-codec",
  "sp-std",
  "wasmtime",
-]
-
-[[package]]
-name = "sp-wasm-interface"
-version = "21.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b066baa6d57951600b14ffe1243f54c47f9c23dd89c262e17ca00ae8dca58be9"
-dependencies = [
- "anyhow",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
 ]
 
 [[package]]
@@ -11457,19 +11245,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "substrate-bip39"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca58ffd742f693dc13d69bdbb2e642ae239e0053f6aab3b104252892f856700a"
-dependencies = [
- "hmac 0.12.1",
- "pbkdf2 0.12.2",
- "schnorrkel",
- "sha2 0.10.8",
- "zeroize",
-]
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11556,7 +11331,7 @@ dependencies = [
  "scale-value",
  "serde",
  "serde_json",
- "sp-core 31.0.0",
+ "sp-core",
  "sp-crypto-hashing",
  "sp-runtime",
  "subxt-metadata",
@@ -12341,7 +12116,6 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time",
  "tracing",
  "tracing-core",
  "tracing-log 0.2.0",
@@ -12356,18 +12130,6 @@ checksum = "ff28e0f815c2fea41ebddf148e008b077d2faddb026c9555b29696114d602642"
 dependencies = [
  "hash-db",
  "hashbrown 0.13.2",
- "log",
- "rustc-hex",
- "smallvec",
-]
-
-[[package]]
-name = "trie-db"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c992b4f40c234a074d48a757efeabb1a6be88af84c0c23f7ca158950cb0ae7f"
-dependencies = [
- "hash-db",
  "log",
  "rustc-hex",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,18 +61,18 @@ subxt = { version = "0.37.0", default-features = false }
 subxt-core = { version = "0.37.0", default-features = false }
 round-based = "0.3.0"
 
-sp-core = { version = "34.0.0", default-features = false }
-sp-io = { version = "38.0.0", default-features = false }
+sp-core = { version = "31.0.0", default-features = false }
+sp-io = { version = "33.0.0", default-features = false }
 sp-std = { version = "14.0.0", default-features = false }
 sp-runtime = { version = "39.0.0", default-features = false }
 sc-utils = { version = "17.0.0", default-features = false }
 sp-api = { version = "34.0.0", default-features = false }
-sp-application-crypto = { version = "38.0.0", default-features = false }
-sp-keystore = { version = "0.40.0", default-features = false }
-sp-externalities = { version = "0.29.0", default-features = false }
+sp-application-crypto = { version = "33.0.0", default-features = false }
+sp-keystore = { version = "0.37.0", default-features = false }
+sp-externalities = { version = "0.27.0", default-features = false }
 
 sc-client-api = { version = "37.0.0", default-features = false }
-sc-keystore = { version = "33.0.0", default-features = false }
+sc-keystore = { version = "28.0.0", default-features = false }
 parity-scale-codec = { version = "3.6.12", default-features = false }
 
 scale-info = { version = "2.11.3", default-features = false }
@@ -122,7 +122,7 @@ structopt = "0.3.26"
 syn = "2.0.75"
 sysinfo = "0.31.2"
 thiserror = { version = "1.0.64", default-features = false }
-tokio = { version = "1.39.3", default-features = false }
+tokio = { version = "1.40", default-features = false }
 tokio-util = { version = "0.7.12", default-features = false }
 toml = "0.8.19"
 tracing = { version = "0.1", default-features = false }

--- a/blueprint-manager/src/executor/mod.rs
+++ b/blueprint-manager/src/executor/mod.rs
@@ -12,7 +12,7 @@ use gadget_sdk::clients::Client;
 use gadget_sdk::info;
 use gadget_sdk::keystore::backend::fs::FilesystemKeystore;
 use gadget_sdk::keystore::backend::GenericKeyStore;
-use gadget_sdk::keystore::{sp_core_subxt, BackendExt, TanglePairSigner};
+use gadget_sdk::keystore::{BackendExt, TanglePairSigner};
 use sp_core::H256;
 use std::collections::HashMap;
 use std::future::Future;
@@ -45,8 +45,8 @@ pub struct BlueprintManagerHandle {
     start_tx: Option<tokio::sync::oneshot::Sender<()>>,
     running_task: JoinHandle<color_eyre::Result<()>>,
     span: tracing::Span,
-    sr25519_id: TanglePairSigner<sp_core_subxt::sr25519::Pair>,
-    ecdsa_id: gadget_sdk::keystore::TanglePairSigner<sp_core_subxt::ecdsa::Pair>,
+    sr25519_id: TanglePairSigner<sp_core::sr25519::Pair>,
+    ecdsa_id: gadget_sdk::keystore::TanglePairSigner<sp_core::ecdsa::Pair>,
     keystore_uri: String,
 }
 
@@ -69,12 +69,12 @@ impl BlueprintManagerHandle {
     }
 
     /// Returns the SR25519 keypair for this blueprint manager
-    pub fn sr25519_id(&self) -> &TanglePairSigner<sp_core_subxt::sr25519::Pair> {
+    pub fn sr25519_id(&self) -> &TanglePairSigner<sp_core::sr25519::Pair> {
         &self.sr25519_id
     }
 
     /// Returns the ECDSA keypair for this blueprint manager
-    pub fn ecdsa_id(&self) -> &gadget_sdk::keystore::TanglePairSigner<sp_core_subxt::ecdsa::Pair> {
+    pub fn ecdsa_id(&self) -> &gadget_sdk::keystore::TanglePairSigner<sp_core::ecdsa::Pair> {
         &self.ecdsa_id
     }
 

--- a/blueprint-test-utils/src/lib.rs
+++ b/blueprint-test-utils/src/lib.rs
@@ -12,7 +12,7 @@ use gadget_sdk::tangle_subxt::tangle_testnet_runtime::api::services::calls::type
 use gadget_sdk::keystore;
 use gadget_sdk::keystore::backend::fs::FilesystemKeystore;
 use gadget_sdk::keystore::backend::GenericKeyStore;
-use gadget_sdk::keystore::{sp_core_subxt, Backend, BackendExt, TanglePairSigner};
+use gadget_sdk::keystore::{Backend, BackendExt, TanglePairSigner};
 use libp2p::Multiaddr;
 pub use log;
 use sp_core::Pair as PairT;
@@ -162,10 +162,8 @@ async fn inject_test_keys<P: AsRef<Path>>(
     let secret_key_again = keystore::sr25519::secret_from_bytes(&bytes).expect("Should be valid");
     assert_eq!(&bytes[..], &secret_key_again.to_bytes()[..]);
 
-    use gadget_sdk::keystore::sp_core_subxt;
     let sr2 = TanglePairSigner::new(
-        sp_core_subxt::sr25519::Pair::from_seed_slice(&bytes)
-            .expect("Should be valid SR25519 keypair"),
+        sp_core::sr25519::Pair::from_seed_slice(&bytes).expect("Should be valid SR25519 keypair"),
     );
 
     let sr1_account_id: AccountId32 = AccountId32(sr.as_ref().public.to_bytes());
@@ -197,7 +195,7 @@ async fn inject_test_keys<P: AsRef<Path>>(
 
 pub async fn create_blueprint(
     client: &TestClient,
-    account_id: &TanglePairSigner<sp_core_subxt::sr25519::Pair>,
+    account_id: &TanglePairSigner<sp_core::sr25519::Pair>,
     blueprint: Blueprint,
 ) -> Result<(), Box<dyn Error>> {
     let call = api::tx().services().create_blueprint(blueprint);
@@ -211,7 +209,7 @@ pub async fn create_blueprint(
 
 pub async fn join_delegators(
     client: &TestClient,
-    account_id: &TanglePairSigner<sp_core_subxt::sr25519::Pair>,
+    account_id: &TanglePairSigner<sp_core::sr25519::Pair>,
 ) -> Result<(), Box<dyn Error>> {
     info!("Joining delegators ...");
     let call_pre = api::tx()
@@ -228,7 +226,7 @@ pub async fn join_delegators(
 
 pub async fn register_blueprint(
     client: &TestClient,
-    account_id: &TanglePairSigner<sp_core_subxt::sr25519::Pair>,
+    account_id: &TanglePairSigner<sp_core::sr25519::Pair>,
     blueprint_id: u64,
     preferences: Preferences,
     registration_args: RegistrationArgs,
@@ -247,7 +245,7 @@ pub async fn register_blueprint(
 
 pub async fn submit_job(
     client: &TestClient,
-    user: &TanglePairSigner<sp_core_subxt::sr25519::Pair>,
+    user: &TanglePairSigner<sp_core::sr25519::Pair>,
     service_id: u64,
     job_type: Job,
     job_params: Args,
@@ -265,7 +263,7 @@ pub async fn submit_job(
 /// to make a call to run a service, and will have all nodes running the service.
 pub async fn register_service(
     client: &TestClient,
-    user: &TanglePairSigner<sp_core_subxt::sr25519::Pair>,
+    user: &TanglePairSigner<sp_core::sr25519::Pair>,
     blueprint_id: u64,
     test_nodes: Vec<AccountId32>,
 ) -> Result<(), Box<dyn Error>> {

--- a/blueprint-test-utils/src/test_ext.rs
+++ b/blueprint-test-utils/src/test_ext.rs
@@ -35,7 +35,7 @@ use url::Url;
 use std::path::PathBuf;
 use subxt::tx::Signer;
 use gadget_sdk::keystore::KeystoreUriSanitizer;
-use gadget_sdk::keystore::sp_core_subxt::Pair;
+use sp_core::Pair;
 use tracing::Instrument;
 use gadget_sdk::{error, info, warn};
 

--- a/gadget-io/src/imp/standard/keystore.rs
+++ b/gadget-io/src/imp/standard/keystore.rs
@@ -1,10 +1,11 @@
 use crate::error::{GadgetIoError, Result};
 pub use crate::shared::keystore::SubstrateKeystore;
-use sp_core::{ecdsa, sr25519, ByteArray};
+use sp_core::{ecdsa, sr25519};
 use std::path::{Path, PathBuf};
 use tracing;
 
 use sc_keystore::{Keystore, LocalKeystore};
+use sp_application_crypto::ByteArray;
 use sp_keystore::KeystorePtr;
 use std::sync::Arc;
 

--- a/macros/blueprint-proc-macro/src/event_listener/tangle.rs
+++ b/macros/blueprint-proc-macro/src/event_listener/tangle.rs
@@ -37,7 +37,7 @@ pub(crate) fn generate_tangle_event_handler(
                 self.service_id
             }
 
-            fn signer(&self) -> &gadget_sdk::keystore::TanglePairSigner<gadget_sdk::keystore::sp_core_subxt::sr25519::Pair> {
+            fn signer(&self) -> &gadget_sdk::keystore::TanglePairSigner<gadget_sdk::ext::sp_core::sr25519::Pair> {
                 &self.signer
             }
         }

--- a/macros/blueprint-proc-macro/src/job.rs
+++ b/macros/blueprint-proc-macro/src/job.rs
@@ -399,7 +399,7 @@ pub fn generate_autogen_struct(
     if job_args.event_listener.has_tangle() {
         required_fields.push(quote! {
             pub service_id: u64,
-            pub signer: gadget_sdk::keystore::TanglePairSigner<gadget_sdk::keystore::sp_core_subxt::sr25519::Pair>,
+            pub signer: gadget_sdk::keystore::TanglePairSigner<gadget_sdk::ext::sp_core::sr25519::Pair>,
             pub client: gadget_sdk::clients::tangle::runtime::TangleClient,
         })
     }

--- a/macros/blueprint-proc-macro/src/report.rs
+++ b/macros/blueprint-proc-macro/src/report.rs
@@ -367,7 +367,7 @@ fn generate_job_report_event_handler(
         #[derive(Clone)]
         pub struct #struct_name {
             pub service_id: u64,
-            pub signer: gadget_sdk::keystore::TanglePairSigner<gadget_sdk::keystore::sp_core_subxt::sr25519::Pair>,
+            pub signer: gadget_sdk::keystore::TanglePairSigner<gadget_sdk::ext::sp_core::sr25519::Pair>,
             pub client: gadget_sdk::clients::tangle::runtime::TangleClient,
         }
 
@@ -395,7 +395,7 @@ fn generate_job_report_event_handler(
                 self.service_id
             }
 
-            fn signer(&self) -> &gadget_sdk::keystore::TanglePairSigner<gadget_sdk::keystore::sp_core_subxt::sr25519::Pair> {
+            fn signer(&self) -> &gadget_sdk::keystore::TanglePairSigner<gadget_sdk::ext::sp_core::sr25519::Pair> {
                 &self.signer
             }
         }
@@ -467,7 +467,7 @@ fn generate_qos_report_event_handler(
         #[derive(Clone)]
         pub struct #struct_name {
             pub service_id: u64,
-            pub signer: gadget_sdk::keystore::TanglePairSigner<gadget_sdk::keystore::sp_core_subxt::sr25519::Pair>,
+            pub signer: gadget_sdk::keystore::TanglePairSigner<gadget_sdk::ext::sp_core::sr25519::Pair>,
             pub client: gadget_sdk::clients::tangle::runtime::TangleClient,
         }
 
@@ -509,7 +509,7 @@ fn generate_qos_report_event_handler(
                 self.service_id
             }
 
-            fn signer(&self) -> &gadget_sdk::keystore::TanglePairSigner<gadget_sdk::keystore::sp_core_subxt::sr25519::Pair> {
+            fn signer(&self) -> &gadget_sdk::keystore::TanglePairSigner<gadget_sdk::ext::sp_core::sr25519::Pair> {
                 &self.signer
             }
         }

--- a/sdk/src/clients/tangle/services.rs
+++ b/sdk/src/clients/tangle/services.rs
@@ -1,9 +1,9 @@
 use crate::error::Error;
 use sp_core::Encode;
+use subxt::backend::BlockRef;
 use subxt::utils::AccountId32;
-use tangle_subxt::subxt::backend::BlockRef;
-use tangle_subxt::subxt::utils::H256;
-use tangle_subxt::subxt::{Config, OnlineClient};
+use subxt::utils::H256;
+use subxt::{Config, OnlineClient};
 use tangle_subxt::tangle_testnet_runtime::api;
 use tangle_subxt::tangle_testnet_runtime::api::runtime_types::sp_runtime::DispatchError;
 use tangle_subxt::tangle_testnet_runtime::api::runtime_types::tangle_primitives::services;

--- a/sdk/src/config.rs
+++ b/sdk/src/config.rs
@@ -2,7 +2,7 @@ use crate::keystore::backend::GenericKeyStore;
 #[cfg(any(feature = "std", feature = "wasm"))]
 use crate::keystore::BackendExt;
 #[cfg(any(feature = "std", feature = "wasm"))]
-use crate::keystore::{sp_core_subxt, TanglePairSigner};
+use crate::keystore::TanglePairSigner;
 use alloc::string::{String, ToString};
 use core::fmt::Debug;
 use core::net::IpAddr;
@@ -382,9 +382,7 @@ impl<RwLock: lock_api::RawRwLock> GadgetConfiguration<RwLock> {
     /// * The keypair seed is invalid.
     #[doc(alias = "sr25519_signer")]
     #[cfg(any(feature = "std", feature = "wasm"))]
-    pub fn first_sr25519_signer(
-        &self,
-    ) -> Result<TanglePairSigner<sp_core_subxt::sr25519::Pair>, Error> {
+    pub fn first_sr25519_signer(&self) -> Result<TanglePairSigner<sp_core::sr25519::Pair>, Error> {
         self.keystore()?.sr25519_key().map_err(Error::Keystore)
     }
 
@@ -396,9 +394,7 @@ impl<RwLock: lock_api::RawRwLock> GadgetConfiguration<RwLock> {
     /// * The keypair seed is invalid.
     #[doc(alias = "ecdsa_signer")]
     #[cfg(any(feature = "std", feature = "wasm"))]
-    pub fn first_ecdsa_signer(
-        &self,
-    ) -> Result<TanglePairSigner<sp_core_subxt::ecdsa::Pair>, Error> {
+    pub fn first_ecdsa_signer(&self) -> Result<TanglePairSigner<sp_core::ecdsa::Pair>, Error> {
         self.keystore()?.ecdsa_key().map_err(Error::Keystore)
     }
 
@@ -410,9 +406,7 @@ impl<RwLock: lock_api::RawRwLock> GadgetConfiguration<RwLock> {
     /// * The keypair seed is invalid.
     #[doc(alias = "ed25519_signer")]
     #[cfg(any(feature = "std", feature = "wasm"))]
-    pub fn first_ed25519_signer(
-        &self,
-    ) -> Result<TanglePairSigner<sp_core_subxt::ed25519::Pair>, Error> {
+    pub fn first_ed25519_signer(&self) -> Result<TanglePairSigner<sp_core::ed25519::Pair>, Error> {
         self.keystore()?.ed25519_key().map_err(Error::Keystore)
     }
 

--- a/sdk/src/events_watcher/substrate.rs
+++ b/sdk/src/events_watcher/substrate.rs
@@ -35,7 +35,5 @@ where
     fn service_id(&self) -> u64;
 
     /// Returns the signer
-    fn signer(
-        &self,
-    ) -> &crate::keystore::TanglePairSigner<crate::keystore::sp_core_subxt::sr25519::Pair>;
+    fn signer(&self) -> &crate::keystore::TanglePairSigner<sp_core::sr25519::Pair>;
 }

--- a/sdk/src/job_runner.rs
+++ b/sdk/src/job_runner.rs
@@ -1,8 +1,8 @@
 use crate::config::GadgetConfiguration;
 use crate::event_listener::markers;
 use crate::events_watcher::InitializableEventHandler;
-use crate::keystore::sp_core_subxt::Pair;
 use crate::{info, tx};
+use sp_core::Pair;
 use std::future::Future;
 use std::pin::Pin;
 use tangle_subxt::tangle_testnet_runtime::api;

--- a/sdk/src/keystore/backend/mod.rs
+++ b/sdk/src/keystore/backend/mod.rs
@@ -13,8 +13,6 @@ pub mod mem;
 #[cfg(feature = "std")]
 pub mod fs;
 
-use crate::keystore::sp_core_subxt;
-
 /// A Generic Key Store that can be backed by different keystore [`Backend`]s.
 ///
 /// [Backend]: super::Backend
@@ -35,12 +33,12 @@ impl<RwLock: lock_api::RawRwLock> GenericKeyStore<RwLock> {
     pub fn create_sr25519_from_pair<T: Into<sp_core::sr25519::Pair>>(
         &self,
         pair: T,
-    ) -> Result<TanglePairSigner<sp_core_subxt::sr25519::Pair>, Error> {
+    ) -> Result<TanglePairSigner<sp_core::sr25519::Pair>, Error> {
         let seed = &pair.into().as_ref().secret.to_bytes();
         let _ = self.sr25519_generate_new(Some(seed))?;
         Ok(TanglePairSigner {
             pair: subxt::tx::PairSigner::new(
-                sp_core_subxt::sr25519::Pair::from_seed_slice(seed).map_err(err_to_std_io_err)?,
+                sp_core::sr25519::Pair::from_seed_slice(seed).map_err(err_to_std_io_err)?,
             ),
         })
     }
@@ -49,13 +47,13 @@ impl<RwLock: lock_api::RawRwLock> GenericKeyStore<RwLock> {
     pub fn create_ecdsa_from_pair<T: Into<sp_core::ecdsa::Pair>>(
         &self,
         pair: T,
-    ) -> Result<TanglePairSigner<sp_core_subxt::ecdsa::Pair>, Error> {
+    ) -> Result<TanglePairSigner<sp_core::ecdsa::Pair>, Error> {
         let seed = pair.into().seed();
         let _ = self.ecdsa_generate_new(Some(&seed))?;
 
         Ok(TanglePairSigner {
             pair: subxt::tx::PairSigner::new(
-                sp_core_subxt::ecdsa::Pair::from_seed_slice(&seed).map_err(err_to_std_io_err)?,
+                sp_core::ecdsa::Pair::from_seed_slice(&seed).map_err(err_to_std_io_err)?,
             ),
         })
     }
@@ -64,13 +62,13 @@ impl<RwLock: lock_api::RawRwLock> GenericKeyStore<RwLock> {
     pub fn create_ed25519_from_pair<T: Into<sp_core::ed25519::Pair>>(
         &self,
         pair: T,
-    ) -> Result<TanglePairSigner<sp_core_subxt::ed25519::Pair>, Error> {
+    ) -> Result<TanglePairSigner<sp_core::ed25519::Pair>, Error> {
         let seed = pair.into().seed();
         let _ = self.ed25519_generate_new(Some(&seed))?;
 
         Ok(TanglePairSigner {
             pair: subxt::tx::PairSigner::new(
-                sp_core_subxt::ed25519::Pair::from_seed_slice(&seed).map_err(err_to_std_io_err)?,
+                sp_core::ed25519::Pair::from_seed_slice(&seed).map_err(err_to_std_io_err)?,
             ),
         })
     }

--- a/sdk/src/keystore/mod.rs
+++ b/sdk/src/keystore/mod.rs
@@ -45,15 +45,13 @@ pub mod error;
 pub mod sr25519;
 
 use crate::clients::tangle::runtime::TangleConfig;
-use crate::keystore::sp_core_subxt::crypto::{DeriveError, SecretStringError};
-use crate::keystore::sp_core_subxt::DeriveJunction;
 #[cfg(any(feature = "std", feature = "wasm"))]
-// TODO: Once subxt uses sp-core 34.0.0, we can simply use sp_core
-pub use crate::tangle_subxt::subxt::ext::sp_core as sp_core_subxt;
 use alloy_signer_local::LocalSigner;
 use eigensdk::crypto_bls;
 pub use error::Error;
 use k256::ecdsa::SigningKey;
+use sp_core::crypto::{DeriveError, SecretStringError};
+use sp_core::DeriveJunction;
 use std::path::{Path, PathBuf};
 use subxt::ext::sp_core::Pair as PairSubxt;
 use subxt_core::tx::signer::{PairSigner, Signer};
@@ -68,15 +66,15 @@ pub struct TanglePairSigner<Pair> {
 }
 
 #[cfg(any(feature = "std", feature = "wasm"))]
-impl<Pair: sp_core_subxt::Pair> sp_core_subxt::crypto::CryptoType for TanglePairSigner<Pair> {
+impl<Pair: sp_core::Pair> sp_core::crypto::CryptoType for TanglePairSigner<Pair> {
     type Pair = Pair;
 }
 
 #[cfg(any(feature = "std", feature = "wasm"))]
-impl<Pair: sp_core_subxt::Pair> TanglePairSigner<Pair>
+impl<Pair: sp_core::Pair> TanglePairSigner<Pair>
 where
-    <Pair as sp_core_subxt::Pair>::Signature: Into<MultiSignature>,
-    subxt::ext::sp_runtime::MultiSigner: From<<Pair as sp_core_subxt::Pair>::Public>,
+    <Pair as sp_core::Pair>::Signature: Into<MultiSignature>,
+    subxt::ext::sp_runtime::MultiSigner: From<<Pair as sp_core::Pair>::Public>,
 {
     pub fn new(pair: Pair) -> Self {
         TanglePairSigner {
@@ -96,7 +94,7 @@ where
 #[cfg(any(feature = "std", feature = "wasm"))]
 impl<Pair> Signer<TangleConfig> for TanglePairSigner<Pair>
 where
-    Pair: sp_core_subxt::Pair,
+    Pair: sp_core::Pair,
     Pair::Signature: Into<MultiSignature>,
 {
     fn account_id(&self) -> AccountId32 {
@@ -113,10 +111,10 @@ where
 }
 
 #[cfg(any(feature = "std", feature = "wasm"))]
-impl<Pair: sp_core_subxt::Pair> sp_core_subxt::Pair for TanglePairSigner<Pair>
+impl<Pair: sp_core::Pair> sp_core::Pair for TanglePairSigner<Pair>
 where
-    <Pair as sp_core_subxt::Pair>::Signature: Into<subxt::utils::MultiSignature>,
-    subxt::ext::sp_runtime::MultiSigner: From<<Pair as sp_core_subxt::Pair>::Public>,
+    <Pair as sp_core::Pair>::Signature: Into<subxt::utils::MultiSignature>,
+    subxt::ext::sp_runtime::MultiSigner: From<<Pair as sp_core::Pair>::Public>,
 {
     type Public = Pair::Public;
     type Seed = Pair::Seed;
@@ -160,7 +158,7 @@ where
     }
 }
 
-impl TanglePairSigner<sp_core_subxt::ecdsa::Pair> {
+impl TanglePairSigner<sp_core::ecdsa::Pair> {
     /// Returns the alloy-compatible key for the ECDSA key pair.
     pub fn alloy_key(&self) -> Result<LocalSigner<SigningKey>, Error> {
         let k256_ecdsa_secret_key = self.pair.signer().seed();
@@ -331,7 +329,7 @@ pub trait Backend {
 /// that provide convenient access to keys
 pub trait BackendExt: Backend {
     #[cfg(any(feature = "std", feature = "wasm"))]
-    fn ecdsa_key(&self) -> Result<TanglePairSigner<sp_core_subxt::ecdsa::Pair>, Error> {
+    fn ecdsa_key(&self) -> Result<TanglePairSigner<sp_core::ecdsa::Pair>, Error> {
         let first_key = self
             .iter_ecdsa()
             .next()
@@ -343,12 +341,12 @@ pub trait BackendExt: Backend {
         let mut seed = [0u8; 32];
         seed.copy_from_slice(&ecdsa_secret.to_bytes()[0..32]);
         Ok(TanglePairSigner {
-            pair: subxt::tx::PairSigner::new(sp_core_subxt::ecdsa::Pair::from_seed(&seed)),
+            pair: subxt::tx::PairSigner::new(sp_core::ecdsa::Pair::from_seed(&seed)),
         })
     }
 
     #[cfg(any(feature = "std", feature = "wasm"))]
-    fn sr25519_key(&self) -> Result<TanglePairSigner<sp_core_subxt::sr25519::Pair>, Error> {
+    fn sr25519_key(&self) -> Result<TanglePairSigner<sp_core::sr25519::Pair>, Error> {
         let first_key = self
             .iter_sr25519()
             .next()
@@ -361,7 +359,7 @@ pub trait BackendExt: Backend {
         Ok(TanglePairSigner { pair })
     }
 
-    fn ed25519_key(&self) -> Result<TanglePairSigner<sp_core_subxt::ed25519::Pair>, Error> {
+    fn ed25519_key(&self) -> Result<TanglePairSigner<sp_core::ed25519::Pair>, Error> {
         let first_key = self
             .iter_ed25519()
             .next()
@@ -373,7 +371,7 @@ pub trait BackendExt: Backend {
         let mut seed = [0u8; 32];
         seed.copy_from_slice(&ed25519_secret.as_ref()[0..32]);
         Ok(TanglePairSigner {
-            pair: subxt::tx::PairSigner::new(sp_core_subxt::ed25519::Pair::from_seed(&seed)),
+            pair: subxt::tx::PairSigner::new(sp_core::ed25519::Pair::from_seed(&seed)),
         })
     }
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -72,6 +72,7 @@ pub use alloy_rpc_types;
 pub use error::Error;
 pub use futures;
 pub use gadget_blueprint_proc_macro::*;
+pub use libp2p;
 pub use parking_lot;
 pub use structopt;
 pub use subxt_core;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -84,6 +84,7 @@ pub mod ext {
     pub use lock_api;
     #[cfg(feature = "std")]
     pub use parking_lot;
+    pub use sp_core;
     pub use tangle_subxt;
     pub use tangle_subxt::subxt;
     pub use tangle_subxt::subxt_signer;


### PR DESCRIPTION
It's currently impossible to use some APIs downstream, since they expose `sp_core` (v0.34.0) types instead of the `sdk::keystore::sp_core_subxt` (v0.31.0) types. Cargo will refuse to build blueprints using them. I just got rid of the `sdk::keystore::sp_core_subxt` hack and downgraded all of the dependencies necessary (I think).

This won't be an issue once #318 is taken care of.

I also re-exported `libp2p` for convenience.