### PR TITLE
fix(sdk): updated keystore support and fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,4 +122,4 @@ jobs:
         run: cargo install cargo-nextest --locked
 
       - name: tests
-        run: cargo nextest run --nocapture --package ${{ matrix.package }}
+        run: cargo nextest run --nocapture --package ${{ matrix.package }} ${{ matrix.package == 'gadget-sdk' && '--features getrandom,std' || '' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,9 +1930,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 dependencies = [
  "serde",
 ]
@@ -2061,12 +2061,14 @@ dependencies = [
  "escargot",
  "gadget-blueprint-proc-macro-core",
  "gadget-sdk",
+ "hex",
  "k256",
  "serde_json",
  "subxt",
  "tangle-subxt",
  "tokio",
  "tracing-subscriber 0.3.18",
+ "w3f-bls",
 ]
 
 [[package]]
@@ -8685,9 +8687,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -9807,13 +9809,13 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.11.3"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca070c12893629e2cc820a9761bedf6ce1dcddc9852984d1dc734b8bd9bd024"
+checksum = "22760a375f81a31817aeaf6f5081e9ccb7ffd7f2da1809a6e3fc82b6656f10d5"
 dependencies = [
  "bitvec",
  "cfg-if",
- "derive_more 0.99.18",
+ "derive_more 1.0.0",
  "parity-scale-codec",
  "scale-info-derive",
  "serde",
@@ -9821,9 +9823,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.11.3"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d35494501194174bda522a32605929eefc9ecf7e0a326c26db1fdd85881eb62"
+checksum = "abc61ebe25a5c410c0e245028fc9934bf8fa4817199ef5a24a68092edfd34614"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -10061,9 +10063,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.212"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "ccd4055b7e3937a5c2595e974f5bf1715a23919a595a04b5ad959bdbbb61ab04"
 dependencies = [
  "serde_derive",
 ]
@@ -10090,9 +10092,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.212"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "726adf8349784fb68a42e6466f49362ae039d9c5333cc6eb131f4d6f94bb9126"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11365,9 +11367,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.37.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f41eb2e2eea6ed45649508cc735f92c27f1fcfb15229e75f8270ea73177345"
+checksum = "3af3b36405538a36b424d229dc908d1396ceb0994c90825ce928709eac1a159a"
 dependencies = [
  "base58",
  "blake2",
@@ -11844,9 +11846,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,10 +128,11 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.36"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94c225801d42099570d0674701dddd4142f0ef715282aeb5985042e2ec962df7"
+checksum = "d4932d790c723181807738cf1ac68198ab581cd699545b155601332541ee47bd"
 dependencies = [
+ "alloy-primitives 0.8.9",
  "num_enum",
  "strum",
 ]
@@ -143,7 +144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da374e868f54c7f4ad2ad56829827badca388efd645f8cf5fccc61c2b5343504"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-rlp",
  "alloy-serde",
  "c-kzg",
@@ -159,7 +160,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-network",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-provider",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
@@ -176,14 +177,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413902aa18a97569e60f679c23f46a18db1656d87ab4d4e49d0e1e52042f66df"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-sol-type-parser",
  "alloy-sol-types",
  "const-hex",
  "itoa",
  "serde",
  "serde_json",
- "winnow 0.6.20",
+ "winnow",
 ]
 
 [[package]]
@@ -192,7 +193,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f76ecab54890cdea1e4808fc0891c7e6cfcf71fe1a9fe26810c7280ef768f4ed"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-rlp",
  "alloy-serde",
  "c-kzg",
@@ -207,7 +208,7 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc05b04ac331a9f07e3a4036ef7926e49a8bf84a99a1ccfc7e2ab55a5fcbb372"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
@@ -219,7 +220,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d6f34930b7e3e2744bcc79056c217f00cb2abb33bc5d4ff88da7623c5bb078b"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "serde",
  "serde_json",
  "thiserror",
@@ -235,7 +236,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-json-rpc",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "alloy-signer",
@@ -256,7 +257,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more",
+ "derive_more 0.99.18",
  "hex-literal",
  "itoa",
  "k256",
@@ -265,6 +266,23 @@ dependencies = [
  "rand",
  "ruint",
  "serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71738eb20c42c5fb149571e76536a0f309d142f3957c28791662b96baf77a3d"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more 1.0.0",
+ "hex-literal",
+ "itoa",
+ "paste",
+ "ruint",
  "tiny-keccak",
 ]
 
@@ -279,7 +297,7 @@ dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-network",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
@@ -309,7 +327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a7341322d9bc0e49f6e9fd9f2eb8e30f73806f2dd12cbb3d6bab2694c921f87"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-transport",
  "bimap",
  "futures",
@@ -340,7 +358,7 @@ checksum = "4d0f2d905ebd295e7effec65e5f6868d153936130ae718352771de3e7d03c75c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -350,7 +368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ba31bae67773fd5a60020bea900231f8396202b7feca4d0c70c6b59308ab4a8"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
@@ -386,7 +404,7 @@ checksum = "ab4123ee21f99ba4bd31bfa36ba89112a18a500f8b452f02b35708b1b951e2b9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
@@ -402,7 +420,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9416c52959e66ead795a11f4a86c248410e9e368a0765710e57055b8a1774dd6"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "serde",
  "serde_json",
 ]
@@ -413,7 +431,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b33753c09fa1ad85e5b092b8dc2372f1e337a42e84b9b4cff9fede75ba4adb32"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "async-trait",
  "auto_impl",
  "elliptic-curve",
@@ -429,7 +447,7 @@ checksum = "63ce17bfd5aa38e14b9c83b553d93c76e1bd5641a2db45f381f81619fd3e54ca"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-signer",
  "async-trait",
  "aws-sdk-kms",
@@ -447,7 +465,7 @@ checksum = "6dfc9c26fe6c6f1bad818c9a976de9044dd12e1f75f1f156a801ee3e8148c1b6"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-signer",
  "async-trait",
  "k256",
@@ -466,7 +484,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -483,7 +501,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -501,7 +519,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.79",
+ "syn 2.0.82",
  "syn-solidity",
 ]
 
@@ -512,7 +530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbcba3ca07cf7975f15d871b721fb18031eec8bce51103907f6dcce00b255d98"
 dependencies = [
  "serde",
- "winnow 0.6.20",
+ "winnow",
 ]
 
 [[package]]
@@ -522,7 +540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a91ca40fa20793ae9c3841b83e74569d1cc9af29a2f5237314fd3452d51e38c7"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-sol-macro",
  "const-hex",
  "serde",
@@ -556,7 +574,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "reqwest 0.12.8",
  "serde_json",
@@ -575,7 +593,7 @@ dependencies = [
  "alloy-transport",
  "futures",
  "http 1.1.0",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "serde_json",
  "tokio",
  "tokio-tungstenite 0.23.1",
@@ -658,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 
 [[package]]
 name = "anymap2"
@@ -937,7 +955,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "synstructure 0.13.1",
 ]
 
@@ -949,7 +967,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1097,7 +1115,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1114,7 +1132,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1213,7 +1231,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1283,14 +1301,14 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tracing",
- "uuid 1.10.0",
+ "uuid 1.11.0",
 ]
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.46.0"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33590e8d45206fdc4273ded8a1f292bcceaadd513037aa790fc67b237bc30ee"
+checksum = "564a597a3c71a957d60a2e4c62c93d78ee5a0d636531e15b760acad983a5c18e"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1373,9 +1391,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce695746394772e7000b39fe073095db6d45a862d0767dd5ad0ac0d7f8eb87"
+checksum = "a065c0fe6fdbdf9f11817eb68582b2ab4aff9e9c39e986ae48f7ec576c6322db"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1388,7 +1406,7 @@ dependencies = [
  "http-body 0.4.6",
  "http-body 1.0.1",
  "httparse",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
@@ -1588,7 +1606,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.79",
+ "syn 2.0.82",
  "which",
 ]
 
@@ -1778,7 +1796,7 @@ name = "blueprint-test-utils"
 version = "0.1.1"
 dependencies = [
  "alloy-contract",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-provider",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
@@ -1806,7 +1824,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
- "uuid 1.10.0",
+ "uuid 1.11.0",
 ]
 
 [[package]]
@@ -1824,7 +1842,7 @@ dependencies = [
  "home",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-named-pipe",
  "hyper-rustls 0.26.0",
  "hyper-util",
@@ -2076,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.28"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "jobserver",
  "libc",
@@ -2250,7 +2268,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2611,7 +2629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2670,7 +2688,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2727,7 +2745,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2749,7 +2767,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2845,7 +2863,7 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2856,7 +2874,7 @@ checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2869,7 +2887,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.79",
+ "syn 2.0.82",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.82",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2956,7 +2995,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2986,7 +3025,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.79",
+ "syn 2.0.82",
  "termcolor",
  "toml",
  "walkdir",
@@ -3147,7 +3186,7 @@ checksum = "92a9242f761ef1403ada3fc268d5373b977c32cf755560019a211d881b343135"
 dependencies = [
  "alloy-eips",
  "alloy-network",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-provider",
  "alloy-rpc-types-eth",
  "alloy-signer-local",
@@ -3166,7 +3205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b545b7b3bb97aa6f769fa329c43e121d3d3ef2c700528c51493d14b7ca4c2b"
 dependencies = [
  "alloy-contract",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-provider",
  "alloy-rpc-types",
  "alloy-signer",
@@ -3190,7 +3229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46b72f6b15b8e641b4b43c1dced1df39cd1b4bcc6ce943ab1ce2280cba6e486f"
 dependencies = [
  "alloy-contract",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "eigen-logging",
  "eigen-types",
  "eigen-utils",
@@ -3207,7 +3246,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-json-rpc",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rlp",
@@ -3230,7 +3269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0327abf48cd09e672456be65e640ee609d23a1989ea1d310b0585e333829f124"
 dependencies = [
  "alloy-contract",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-provider",
  "alloy-rpc-types",
  "chrono",
@@ -3244,7 +3283,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "thiserror",
- "uuid 1.10.0",
+ "uuid 1.11.0",
 ]
 
 [[package]]
@@ -3259,7 +3298,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4016b25de0e41e5f4a8b8c495cef35cbdf5d1946021b472a0ce10b656956465f"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.4.2",
@@ -3337,7 +3376,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b8a3bf7010289fcac159db5a5d89fb3879236ac3c84e7c389366269d512c1da"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "ark-bn254",
  "ark-ec",
  "async-trait",
@@ -3354,7 +3393,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ccce420984d12deb996b6d85580f0080e5b8f6dc10c8858622c24f23953453b"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "ark-bn254",
  "ark-ec",
  "eigen-client-avsregistry",
@@ -3375,7 +3414,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc37b203588165d466fbff505e474b7fdfd4bfdd9095171f171209aeaf57919d"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-provider",
  "alloy-rpc-types",
  "anyhow",
@@ -3399,7 +3438,7 @@ checksum = "e981bde69979d705dbac089181df625f7e54ec01898983a8a1d8d1144b67b83b"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-rpc-client",
  "alloy-signer",
  "alloy-signer-aws",
@@ -3419,7 +3458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b14a2ba9fbb5585ce0b3170243db2dfc551383ea7a46114a2c3f748da4515a"
 dependencies = [
  "alloy-network",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-provider",
  "alloy-transport-http",
  "eigen-utils",
@@ -3436,7 +3475,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59467c722b271730a065a401002a6d3e7f6861233cf6241fda3a94bf863b4d74"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "ark-serialize 0.4.2",
  "eigen-crypto-bls",
  "ethers",
@@ -3575,7 +3614,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3588,7 +3627,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3795,7 +3834,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "syn 2.0.79",
+ "syn 2.0.82",
  "toml",
  "walkdir",
 ]
@@ -3813,7 +3852,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3839,7 +3878,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.79",
+ "syn 2.0.82",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -4026,7 +4065,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4156,9 +4195,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -4370,7 +4409,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4380,7 +4419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-pki-types",
 ]
 
@@ -4461,7 +4500,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.79",
+ "syn 2.0.82",
  "trybuild",
 ]
 
@@ -4495,7 +4534,7 @@ dependencies = [
  "gadget-sdk",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "trybuild",
 ]
 
@@ -4532,7 +4571,7 @@ version = "0.1.2"
 dependencies = [
  "alloy-contract",
  "alloy-network",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-provider",
  "alloy-rpc-types",
  "alloy-signer",
@@ -4558,7 +4597,7 @@ dependencies = [
  "getrandom",
  "hex",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "k256",
  "libp2p",
@@ -4585,6 +4624,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-retry",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber 0.3.18",
  "url",
@@ -4678,7 +4718,7 @@ dependencies = [
  "gix-utils",
  "itoa",
  "thiserror",
- "winnow 0.6.20",
+ "winnow",
 ]
 
 [[package]]
@@ -4699,7 +4739,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "unicode-bom",
- "winnow 0.6.20",
+ "winnow",
 ]
 
 [[package]]
@@ -4802,7 +4842,7 @@ dependencies = [
  "itoa",
  "smallvec",
  "thiserror",
- "winnow 0.6.20",
+ "winnow",
 ]
 
 [[package]]
@@ -4837,7 +4877,7 @@ dependencies = [
  "gix-validate",
  "memmap2",
  "thiserror",
- "winnow 0.6.20",
+ "winnow",
 ]
 
 [[package]]
@@ -5356,9 +5396,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
+version = "0.14.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -5380,9 +5420,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -5406,7 +5446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -5422,7 +5462,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
@@ -5438,7 +5478,7 @@ checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "log",
  "rustls 0.22.4",
@@ -5457,10 +5497,10 @@ checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "log",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
@@ -5476,7 +5516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -5490,7 +5530,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -5509,7 +5549,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -5525,7 +5565,7 @@ checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -5621,7 +5661,7 @@ dependencies = [
  "bytes",
  "futures",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "log",
  "rand",
  "tokio",
@@ -5691,7 +5731,7 @@ dependencies = [
  "alloy-contract",
  "alloy-json-abi",
  "alloy-network",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-types",
@@ -5732,7 +5772,7 @@ dependencies = [
  "alloy-contract",
  "alloy-json-abi",
  "alloy-network",
- "alloy-primitives",
+ "alloy-primitives 0.7.7",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-types",
@@ -5950,9 +5990,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -6017,7 +6057,7 @@ dependencies = [
  "http 1.1.0",
  "jsonrpsee-core 0.23.2",
  "pin-project",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto 0.8.0",
@@ -6040,7 +6080,7 @@ dependencies = [
  "beef",
  "futures-timer",
  "futures-util",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "jsonrpsee-types 0.22.5",
  "pin-project",
  "rustc-hash 1.1.0",
@@ -6083,7 +6123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ccf93fc4a0bfe05d851d37d7c32b7f370fe94336b52a2f0efc5f1981895c2e5"
 dependencies = [
  "async-trait",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyper-rustls 0.24.2",
  "jsonrpsee-core 0.22.5",
  "jsonrpsee-types 0.22.5",
@@ -6265,9 +6305,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libgit2-sys"
@@ -6659,7 +6699,7 @@ dependencies = [
  "quinn",
  "rand",
  "ring 0.17.8",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "socket2",
  "thiserror",
  "tokio",
@@ -6746,7 +6786,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -6778,7 +6818,7 @@ dependencies = [
  "libp2p-identity",
  "rcgen",
  "ring 0.17.8",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-webpki 0.101.7",
  "thiserror",
  "x509-parser",
@@ -6968,7 +7008,7 @@ checksum = "3b51f1d220e3fa869e24cfd75915efe3164bd09bb11b3165db3f37f57bf673e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -7135,7 +7175,7 @@ checksum = "b4f0c8427b39666bf970460908b213ec09b3b350f20c0c2eabcbba51704a08e6"
 dependencies = [
  "base64 0.22.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-rustls 0.27.3",
  "hyper-util",
  "indexmap 2.6.0",
@@ -7466,9 +7506,9 @@ dependencies = [
 
 [[package]]
 name = "ntex"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93daf570cdedb9a01a3020ccd367b2ff37402b30c979aff2da23e3e84d2b6cfc"
+checksum = "223834e688405dcc46b5c28bc9225648c603e64d7b61e8903da33064b6f1464e"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.6.0",
@@ -7525,9 +7565,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-h2"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98763f0ee78f247c02fe1bcdf6380f306a08d95169f9c2d83619d5e1cb26c738"
+checksum = "8e01b86bf30768ed7dca26bf279d0e0798ba5acf0baef4b0ea8e17a91ba71ad4"
 dependencies = [
  "bitflags 2.6.0",
  "fxhash",
@@ -7560,14 +7600,15 @@ dependencies = [
 
 [[package]]
 name = "ntex-io"
-version = "2.6.1"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8e90ceb0a9a1bcb57459b8e14c6257519afc8dc3460d68b507fb12e909d02c"
+checksum = "80c49628e35ff52f36137a8e732261f392de621406a163571888f6163e3f6b10"
 dependencies = [
  "bitflags 2.6.0",
  "log",
  "ntex-bytes",
  "ntex-codec",
+ "ntex-rt",
  "ntex-service",
  "ntex-util",
  "pin-project-lite",
@@ -7616,9 +7657,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-rt"
-version = "0.4.18"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d24cfad65aab77e56ee1f1a218ca248c141a22f6f65aba8ed56037ec3c6f3a4"
+checksum = "76f86c83f89053c29dcf5f1e9663c53726eea337a3221fa243e61e0410a40ad7"
 dependencies = [
  "async-channel",
  "futures-core",
@@ -7650,9 +7691,9 @@ dependencies = [
 
 [[package]]
 name = "ntex-service"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2cc8f131d5fed702d758485fdc45a41dfab69d8ed71b84e2b910b4ea39f795"
+checksum = "02daa9c4fc8b5382b24dd69d504599a72774d6828e4fc21e9013cb62096db7aa"
 dependencies = [
  "slab",
 ]
@@ -7833,10 +7874,10 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -7929,9 +7970,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -7950,7 +7991,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -7970,9 +8011,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
@@ -7989,9 +8030,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d501f1a72f71d3c063a6bbc8f7271fa73aa09fe5d6283b6571e2ed176a2537"
+checksum = "83e7ccb95e240b7c9506a3d544f10d935e142cc90b0a1d56954fb44d89ad6b97"
 dependencies = [
  "num-traits",
 ]
@@ -8048,7 +8089,7 @@ version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -8105,7 +8146,7 @@ dependencies = [
  "regex",
  "regex-syntax 0.8.5",
  "structmeta",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -8243,7 +8284,7 @@ dependencies = [
  "parking_lot",
  "reqwest 0.12.8",
  "serde_json",
- "sp-core 34.0.0",
+ "sp-core",
  "structopt",
  "subxt-signer",
  "tokio",
@@ -8253,9 +8294,9 @@ dependencies = [
 
 [[package]]
 name = "pest"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
  "thiserror",
@@ -8264,9 +8305,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3a6e3394ec80feb3b6393c725571754c6188490265c61aaf260810d6b95aa0"
+checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -8274,22 +8315,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94429506bde1ca69d1b5601962c73f4172ab4726571a59ea95931218cb0e930e"
+checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8a071862e93690b6e34e9a5fb8e33ff3734473ac0245b27232222c4906a33f"
+checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
 dependencies = [
  "once_cell",
  "pest",
@@ -8355,7 +8396,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -8393,7 +8434,7 @@ checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -8485,7 +8526,7 @@ dependencies = [
  "polkavm-common 0.8.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -8497,7 +8538,7 @@ dependencies = [
  "polkavm-common 0.9.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -8507,7 +8548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15e85319a0d5129dc9f021c62607e0804f5fb777a05cdda44d750ac0732def66"
 dependencies = [
  "polkavm-derive-impl 0.8.0",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -8517,7 +8558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
  "polkavm-derive-impl 0.9.0",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -8587,12 +8628,12 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+checksum = "910d41a655dac3b764f1ade94821093d3610248694320cd072303a8eedcf221d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -8611,21 +8652,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.22.22",
+ "toml_edit",
 ]
 
 [[package]]
@@ -8654,9 +8685,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
 dependencies = [
  "unicode-ident",
 ]
@@ -8701,7 +8732,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -8788,7 +8819,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.0.0",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "socket2",
  "thiserror",
  "tokio",
@@ -8805,7 +8836,7 @@ dependencies = [
  "rand",
  "ring 0.17.8",
  "rustc-hash 2.0.0",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "slab",
  "thiserror",
  "tinyvec",
@@ -8990,7 +9021,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -9071,7 +9102,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyper-rustls 0.24.2",
  "hyper-tls 0.5.0",
  "ipnet",
@@ -9117,7 +9148,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-rustls 0.27.3",
  "hyper-tls 0.6.0",
  "hyper-util",
@@ -9130,7 +9161,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-native-certs 0.8.0",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
@@ -9196,7 +9227,7 @@ checksum = "a5a11a05ee1ce44058fa3d5961d05194fdbe3ad6b40f904af764d81b86450e6b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -9493,9 +9524,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.14"
+version = "0.23.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
+checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -9565,9 +9596,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-platform-verifier"
@@ -9580,7 +9611,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-native-certs 0.7.3",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.102.8",
@@ -9620,9 +9651,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "rusty-fork"
@@ -9643,7 +9674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58c4eb8a81997cf040a091d1f7e1938aeab6749d3a0dfa73af43cdc32393483d"
 dependencies = [
  "byteorder",
- "derive_more",
+ "derive_more 0.99.18",
  "twox-hash",
 ]
 
@@ -9725,7 +9756,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e98f3262c250d90e700bb802eb704e1f841e03331c2eb815e46516c4edbf5b27"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.18",
  "parity-scale-codec",
  "primitive-types",
  "scale-bits",
@@ -9748,11 +9779,11 @@ dependencies = [
 
 [[package]]
 name = "scale-encode"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba0b9c48dc0eb20c60b083c29447c0c4617cb7c4a4c9fef72aa5c5bc539e15e"
+checksum = "528464e6ae6c8f98e2b79633bf79ef939552e795e316579dab09c61670d56602"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.18",
  "parity-scale-codec",
  "primitive-types",
  "scale-bits",
@@ -9763,15 +9794,15 @@ dependencies = [
 
 [[package]]
 name = "scale-encode-derive"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ab7e60e2d9c8d47105f44527b26f04418e5e624ffc034f6b4a86c0ba19c5bf"
+checksum = "bef2618f123c88da9cd8853b69d766068f1eddc7692146d7dfe9b89e25ce2efd"
 dependencies = [
- "darling 0.14.4",
- "proc-macro-crate 1.3.1",
+ "darling 0.20.10",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -9782,7 +9813,7 @@ checksum = "eca070c12893629e2cc820a9761bedf6ce1dcddc9852984d1dc734b8bd9bd024"
 dependencies = [
  "bitvec",
  "cfg-if",
- "derive_more",
+ "derive_more 0.99.18",
  "parity-scale-codec",
  "scale-info-derive",
  "serde",
@@ -9794,7 +9825,7 @@ version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d35494501194174bda522a32605929eefc9ecf7e0a326c26db1fdd85881eb62"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -9819,7 +9850,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scale-info",
- "syn 2.0.79",
+ "syn 2.0.82",
  "thiserror",
 ]
 
@@ -9831,7 +9862,7 @@ checksum = "8cd6ab090d823e75cfdb258aad5fe92e13f2af7d04b43a55d607d25fcc38c811"
 dependencies = [
  "base58",
  "blake2",
- "derive_more",
+ "derive_more 0.99.18",
  "either",
  "frame-metadata 15.1.0",
  "parity-scale-codec",
@@ -10065,7 +10096,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -10076,14 +10107,14 @@ checksum = "e578a843d40b4189a4d66bba51d7684f57da5bd7c304c64e14bd63efbef49509"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -10099,7 +10130,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -10150,7 +10181,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -10403,7 +10434,7 @@ dependencies = [
  "bs58",
  "chacha20",
  "crossbeam-queue",
- "derive_more",
+ "derive_more 0.99.18",
  "ed25519-zebra 4.0.3",
  "either",
  "event-listener 4.0.3",
@@ -10453,7 +10484,7 @@ dependencies = [
  "async-lock",
  "base64 0.21.7",
  "blake2-rfc",
- "derive_more",
+ "derive_more 0.99.18",
  "either",
  "event-listener 4.0.3",
  "fnv",
@@ -10648,7 +10679,7 @@ checksum = "48d09fa0a5f7299fb81ee25ae3853d26200f7a348148aed6de76be905c007dbe"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -10766,10 +10797,10 @@ checksum = "0195f32c628fee3ce1dfbbf2e7e52a30ea85f3589da9fe62a8b816d70fc06294"
 dependencies = [
  "Inflector",
  "expander",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -11194,7 +11225,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -11205,7 +11236,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -11251,7 +11282,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -11327,7 +11358,7 @@ dependencies = [
  "scale-info",
  "scale-typegen",
  "subxt-metadata",
- "syn 2.0.79",
+ "syn 2.0.82",
  "thiserror",
  "tokio",
 ]
@@ -11400,7 +11431,7 @@ dependencies = [
  "quote",
  "scale-typegen",
  "subxt-codegen",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -11472,9 +11503,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11490,7 +11521,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -11528,7 +11559,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -11612,6 +11643,12 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-triple"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
 
 [[package]]
 name = "tempfile"
@@ -11726,7 +11763,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -11831,7 +11868,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -11882,7 +11919,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-pki-types",
  "tokio",
 ]
@@ -11922,7 +11959,7 @@ checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -11954,7 +11991,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.22",
+ "toml_edit",
 ]
 
 [[package]]
@@ -11968,17 +12005,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.6.0",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
@@ -11987,7 +12013,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.20",
+ "winnow",
 ]
 
 [[package]]
@@ -12037,7 +12063,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -12175,14 +12201,15 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.99"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "207aa50d36c4be8d8c6ea829478be44a372c6a77669937bb39c698e52f1491e8"
+checksum = "8dcd332a5496c026f1e14b7f3d2b7bd98e509660c04239c58b0ba38a12daded4"
 dependencies = [
  "glob",
  "serde",
  "serde_derive",
  "serde_json",
+ "target-triple",
  "termcolor",
  "toml",
 ]
@@ -12209,7 +12236,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -12245,7 +12272,7 @@ dependencies = [
  "httparse",
  "log",
  "rand",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-pki-types",
  "sha1",
  "thiserror",
@@ -12281,7 +12308,7 @@ checksum = "f9534daa9fd3ed0bd911d462a37f172228077e7abf18c18a5f67199d959205f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -12447,9 +12474,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom",
 ]
@@ -12492,9 +12519,9 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "w3f-bls"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5da5fa2c6afa2c9158eaa7cd9aee249765eb32b5fb0c63ad8b9e79336a47ec"
+checksum = "6a48c48447120a85b0bdb897ba9426a7aa15b4229498a2e19103e8c9368dd4b2"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -12556,9 +12583,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -12567,24 +12594,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -12594,9 +12621,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -12604,22 +12631,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wasmi"
@@ -12805,9 +12832,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtimer"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f656cd8858a5164932d8a90f936700860976ec21eb00e0fe2aa8cab13f6b4cf"
+checksum = "c7ed9d8b15c7fb594d72bfb4b5a276f3d2029333cd93a932f376f5937f6f80ee"
 dependencies = [
  "futures",
  "js-sys",
@@ -12819,9 +12846,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -12969,7 +12996,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -12980,7 +13007,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -13238,15 +13265,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
@@ -13406,7 +13424,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -13426,7 +13444,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ syn = "2.0.75"
 sysinfo = "0.31.2"
 thiserror = { version = "1.0.64", default-features = false }
 tokio = { version = "1.40", default-features = false }
+tokio-stream = { version = "0.1.16", default-features = false }
 tokio-util = { version = "0.7.12", default-features = false }
 toml = "0.8.19"
 tracing = { version = "0.1", default-features = false }

--- a/blueprint-metadata/src/lib.rs
+++ b/blueprint-metadata/src/lib.rs
@@ -15,7 +15,7 @@ use rustdoc_types::{Crate, Id, Item, ItemEnum, Module};
 
 /// Generate `blueprint.json` to the current crate working directory next to `build.rs` file.
 pub fn generate_json() {
-    Config::builder().build().generate_json();
+    // Config::builder().build().generate_json();
 }
 
 #[derive(Debug, Clone, Default, typed_builder::TypedBuilder)]

--- a/blueprint-test-utils/src/anvil.rs
+++ b/blueprint-test-utils/src/anvil.rs
@@ -8,8 +8,6 @@ use tokio::io::AsyncBufReadExt;
 
 const ANVIL_IMAGE: &str = "ghcr.io/foundry-rs/foundry";
 const ANVIL_TAG: &str = "nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a";
-const ANVIL_STATE_PATH: &str =
-    "./blueprint-test-utils/anvil/deployed_anvil_states/testnet_state.json";
 
 fn workspace_dir() -> PathBuf {
     let output = std::process::Command::new(env!("CARGO"))
@@ -25,9 +23,10 @@ fn workspace_dir() -> PathBuf {
 
 /// Start an Anvil container for testing with contract state loaded.
 pub async fn start_anvil_container(
+    state_path: &str,
     include_logs: bool,
 ) -> (ContainerAsync<GenericImage>, String, String) {
-    let relative_path = PathBuf::from(ANVIL_STATE_PATH);
+    let relative_path = PathBuf::from(state_path);
     let absolute_path = workspace_dir().join(relative_path);
     let absolute_path_str = absolute_path.to_str().unwrap();
 

--- a/blueprint-test-utils/src/lib.rs
+++ b/blueprint-test-utils/src/lib.rs
@@ -155,7 +155,7 @@ pub async fn inject_test_keys<P: AsRef<Path>>(
         .ecdsa_generate_new(Some(&ecdsa_seed))
         .expect("Should be valid ECDSA seed");
     keystore
-        .bls_bn254_generate_from_secret(
+        .bls_bn254_generate_from_string(
             "1371012690269088913462269866874713266643928125698382731338806296762673180359922"
                 .to_string(),
         )

--- a/blueprints/incredible-squaring-eigenlayer/src/lib.rs
+++ b/blueprints/incredible-squaring-eigenlayer/src/lib.rs
@@ -437,7 +437,7 @@ pub fn convert_to_g1_point(
     })
 }
 
-/// Convert [`G2Affine`] to [`G2Point`]
+/// Convert [`G2Affine`] to [`G2Point`](IncredibleSquaringTaskManager::G2Point)
 pub fn convert_to_g2_point(
     g2: ark_bn254::G2Affine,
 ) -> Result<IncredibleSquaringTaskManager::G2Point> {

--- a/cli/src/create.rs
+++ b/cli/src/create.rs
@@ -56,20 +56,16 @@ pub fn new_blueprint(name: String, source: Option<Source>) {
     let source = source.unwrap_or_default();
     let template_path_opt: Option<cargo_generate::TemplatePath> = source.into();
 
-    let template_path;
-    match template_path_opt {
-        Some(tp) => template_path = tp,
-        None => {
-            // TODO: Interactive selection (#352)
-            template_path = cargo_generate::TemplatePath {
-                git: Some(String::from(
-                    "https://github.com/tangle-network/blueprint-template/",
-                )),
-                branch: Some(String::from("main")),
-                ..Default::default()
-            };
+    let template_path = template_path_opt.unwrap_or_else(|| {
+        // TODO: Interactive selection (#352)
+        cargo_generate::TemplatePath {
+            git: Some(String::from(
+                "https://github.com/tangle-network/blueprint-template/",
+            )),
+            branch: Some(String::from("main")),
+            ..Default::default()
         }
-    }
+    });
 
     let path = cargo_generate::generate(cargo_generate::GenerateArgs {
         template_path,

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -21,6 +21,7 @@ sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite"], option
 parking_lot = { workspace = true, optional = true }
 rand = { workspace = true, features = ["alloc"] }
 thiserror = { workspace = true }
+tokio-stream = { workspace = true, features = ["io-util", "sync"] }
 structopt = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 failure = { workspace = true }

--- a/sdk/src/keystore/backend/fs.rs
+++ b/sdk/src/keystore/backend/fs.rs
@@ -1,11 +1,13 @@
 //! Filesystem-based keystore backend.
 
+use crate::keystore::bn254::Public;
 use crate::keystore::{
     bls381, bn254, ecdsa, ed25519, sr25519, Backend, Error, KeystoreUriSanitizer,
 };
 use crate::{debug, warn};
 use alloc::string::ToString;
 use ark_serialize::CanonicalSerialize;
+use core::str::FromStr;
 use std::{fs, io::Write, path::PathBuf};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -43,7 +45,7 @@ impl FilesystemKeystore {
 
     /// Write the given `data` to `file`.
     fn write_to_file(file: PathBuf, data: &[u8]) -> Result<(), Error> {
-        let mut file = fs::File::create(file)?;
+        let mut file = fs::File::create(file).unwrap();
 
         #[cfg(target_family = "unix")]
         {
@@ -94,17 +96,29 @@ impl FilesystemKeystore {
     /// Iterate over all public keys of a given key type.
     /// skipping any invalid files.
     fn iter_keys(&self, key_type: KeyType) -> Box<dyn Iterator<Item = Vec<u8>>> {
-        let key_type = key_type as u16;
-        let key_type = key_type.to_be_bytes();
-        let prefix = hex::encode(key_type);
+        let key_type_u16 = key_type as u16;
+        let key_type_bytes = key_type_u16.to_be_bytes();
+        let prefix = hex::encode(key_type_bytes);
         let res = fs::read_dir(&self.root);
         match res {
             Ok(r) => Box::new(r.filter_map(move |entry| {
                 let entry = entry.ok()?;
                 let file_name = entry.file_name().into_string().ok()?;
+
+                // If the key type is BlsBn254, search for .pub files. Otherwise, search normally
                 if file_name.starts_with(&prefix) {
-                    let public = file_name.strip_prefix(&prefix)?;
-                    hex::decode(public).ok()
+                    if key_type == KeyType::BlsBn254 {
+                        if file_name.ends_with(".pub") {
+                            let public_key_path = entry.path();
+                            let public_key_bytes = fs::read(public_key_path).ok()?;
+                            Some(public_key_bytes)
+                        } else {
+                            None
+                        }
+                    } else {
+                        let public_key_file = file_name.strip_prefix(&prefix)?;
+                        hex::decode(public_key_file).ok()
+                    }
                 } else {
                     None
                 }
@@ -213,16 +227,58 @@ impl Backend for FilesystemKeystore {
         let secret = bn254::generate_with_optional_seed(seed);
         let public = bn254::to_public(&secret);
         let path = self.key_file_path(
-            serde_json::to_vec(&public)
-                .map_err(|e| Error::BlsBn254(e.to_string()))?
-                .as_slice(),
+            bn254::hash_public(public.clone())?.as_bytes(),
             KeyType::BlsBn254,
         );
+
+        // Serialize and store the secret key
         let mut secret_bytes = Vec::new();
         secret
             .serialize_uncompressed(&mut secret_bytes)
             .map_err(|e| Error::BlsBn254(e.to_string()))?;
-        Self::write_to_file(path, &secret_bytes)?;
+        Self::write_to_file(path.clone(), &secret_bytes)?;
+
+        // Store the public key in metadata file
+        let public_key_path = path.with_extension("pub");
+        Self::write_to_file(
+            public_key_path,
+            serde_json::to_vec(&public)
+                .map_err(|e| Error::BlsBn254(e.to_string()))?
+                .as_slice(),
+        )?;
+
+        Ok(public)
+    }
+
+    fn bls_bn254_generate_from_secret(&self, secret: String) -> Result<Public, Error> {
+        let pair = eigensdk::crypto_bls::BlsKeyPair::new(secret.clone())
+            .map_err(|e| Error::BlsBn254(e.to_string()))?;
+
+        let public = pair.public_key();
+
+        let path = self.key_file_path(
+            bn254::hash_public(public.clone())?.as_bytes(),
+            KeyType::BlsBn254,
+        );
+        let secret = bn254::Secret::from_str(&secret)
+            .map_err(|_| Error::BlsBn254("Invalid BLS BN254 secret".to_string()))?;
+
+        // Serialize and store the secret key
+        let mut secret_bytes = Vec::new();
+        secret
+            .serialize_uncompressed(&mut secret_bytes)
+            .map_err(|e| Error::BlsBn254(e.to_string()))?;
+        Self::write_to_file(path.clone(), &secret_bytes)?;
+
+        // Store the public key in metadata file
+        let public_key_path = path.with_extension("pub");
+        Self::write_to_file(
+            public_key_path,
+            serde_json::to_vec(&public)
+                .map_err(|e| Error::BlsBn254(e.to_string()))?
+                .as_slice(),
+        )?;
+
         Ok(public)
     }
 
@@ -231,14 +287,10 @@ impl Backend for FilesystemKeystore {
         public: &bn254::Public,
         msg: &[u8; 32],
     ) -> Result<Option<bn254::Signature>, Error> {
-        let secret_bytes = self.secret_by_type(
-            serde_json::to_vec(&public)
-                .map_err(|e| Error::BlsBn254(e.to_string()))?
-                .as_slice(),
-            KeyType::BlsBn254,
-        )?;
+        let hashed_public = bn254::hash_public(public.clone())?;
+        let secret_bytes = self.secret_by_type(hashed_public.as_bytes(), KeyType::BlsBn254)?;
         if let Some(buf) = secret_bytes {
-            let mut secret = bn254::secret_from_bytes(&buf);
+            let mut secret = bn254::secret_from_bytes(&buf)?;
             Ok(Some(bn254::sign(&mut secret, msg)))
         } else {
             Ok(None)
@@ -299,14 +351,10 @@ impl Backend for FilesystemKeystore {
         &self,
         public: &bn254::Public,
     ) -> Result<Option<bn254::Secret>, Error> {
-        let secret_bytes = self.secret_by_type(
-            serde_json::to_vec(&public)
-                .map_err(|e| Error::BlsBn254(e.to_string()))?
-                .as_slice(),
-            KeyType::BlsBn254,
-        )?;
+        let hashed_public = bn254::hash_public(public.clone())?;
+        let secret_bytes = self.secret_by_type(hashed_public.as_bytes(), KeyType::BlsBn254)?;
         if let Some(buf) = secret_bytes {
-            Ok(Some(bn254::secret_from_bytes(&buf)))
+            Ok(Some(bn254::secret_from_bytes(&buf)?))
         } else {
             Ok(None)
         }
@@ -336,6 +384,6 @@ impl Backend for FilesystemKeystore {
 
     fn iter_bls_bn254(&self) -> impl Iterator<Item = bn254::Public> {
         self.iter_keys(KeyType::BlsBn254)
-            .flat_map(|b| serde_json::from_slice(&b))
+            .flat_map(|b| serde_json::from_slice(&b).ok())
     }
 }

--- a/sdk/src/keystore/backend/mem.rs
+++ b/sdk/src/keystore/backend/mem.rs
@@ -211,8 +211,10 @@ impl<RwLock: lock_api::RawRwLock> Backend for InMemoryKeystore<RwLock> {
     }
 
     fn bls_bn254_generate_new(&self, seed: Option<&[u8]>) -> Result<bn254::Public, Error> {
-        let secret = bn254::generate_with_optional_seed(seed);
-        let public = bn254::to_public(&secret);
+        let secret = bn254::generate_with_optional_seed(seed)?;
+        let pair = eigensdk::crypto_bls::BlsKeyPair::new(secret.to_string())
+            .map_err(|e| Error::BlsBn254(e.to_string()))?;
+        let public = pair.public_key();
         let old = self
             .bn254
             .write()

--- a/sdk/src/keystore/backend/mod.rs
+++ b/sdk/src/keystore/backend/mod.rs
@@ -178,6 +178,14 @@ impl<RwLock: lock_api::RawRwLock> super::Backend for GenericKeyStore<RwLock> {
         }
     }
 
+    fn bls_bn254_generate_from_secret(&self, secret: String) -> Result<Public, Error> {
+        match self {
+            Self::Mem(backend) => backend.bls_bn254_generate_from_secret(secret),
+            #[cfg(feature = "std")]
+            Self::Fs(backend) => backend.bls_bn254_generate_from_secret(secret),
+        }
+    }
+
     fn bls_bn254_sign(&self, public: &Public, msg: &[u8; 32]) -> Result<Option<Signature>, Error> {
         match self {
             Self::Mem(backend) => backend.bls_bn254_sign(public, msg),

--- a/sdk/src/keystore/bn254.rs
+++ b/sdk/src/keystore/bn254.rs
@@ -2,11 +2,10 @@
 
 use crate::keystore::Error;
 use alloy_primitives::keccak256;
-use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::{PrimeField, UniformRand};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use eigensdk::crypto_bls::BlsKeyPair;
 use eigensdk::crypto_bls::{BlsG1Point, BlsSignature, PrivateKey};
-use eigensdk::crypto_bls::{BlsKeyPair, PublicKey};
 use elliptic_curve::rand_core::OsRng;
 use k256::sha2::{Digest, Sha256};
 

--- a/sdk/src/keystore/bn254.rs
+++ b/sdk/src/keystore/bn254.rs
@@ -54,10 +54,9 @@ pub fn sign(secret: &mut Secret, msg: &[u8; 32]) -> Signature {
     pair.sign_message(msg.as_slice()).g1_point().g1()
 }
 
-#[must_use]
-pub fn to_public(secret: &Secret) -> Public {
-    let public = PublicKey::generator().mul_bigint(secret.0);
-    Public::new(public.into_affine())
+pub fn to_public(secret: &Secret) -> Result<Public, Error> {
+    let pair = BlsKeyPair::new(secret.to_string()).map_err(|e| Error::BlsBn254(e.to_string()))?;
+    Ok(pair.public_key())
 }
 
 pub fn secret_from_bytes(bytes: &[u8]) -> Result<Secret, Error> {

--- a/sdk/src/keystore/bn254.rs
+++ b/sdk/src/keystore/bn254.rs
@@ -4,10 +4,10 @@ use crate::keystore::Error;
 use alloy_primitives::keccak256;
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::{PrimeField, UniformRand};
-use ark_serialize::CanonicalDeserialize;
-use eigensdk::crypto_bls::PublicKey;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use eigensdk::crypto_bls::{BlsG1Point, BlsSignature, PrivateKey};
-use eigensdk::crypto_bn254::utils::map_to_curve;
+use eigensdk::crypto_bls::{BlsKeyPair, PublicKey};
+use elliptic_curve::rand_core::OsRng;
 use k256::sha2::{Digest, Sha256};
 
 /// BN254 public key.
@@ -29,24 +29,29 @@ pub fn hash_public(public: Public) -> Result<String, Error> {
     Ok(hex::encode(hashed_public))
 }
 
-#[must_use]
-pub fn generate_with_optional_seed(seed: Option<&[u8]>) -> Secret {
+pub fn generate_with_optional_seed(seed: Option<&[u8]>) -> Result<Secret, Error> {
     match seed {
         Some(s) => {
             let hashed_seed = keccak256(s);
-            Secret::from_le_bytes_mod_order(hashed_seed.as_slice())
+            Ok(Secret::from_le_bytes_mod_order(hashed_seed.as_slice()))
         }
         None => {
-            let mut rng = rand::thread_rng();
-            Secret::rand(&mut rng)
+            let mut buffer = Vec::new();
+            let private_key = Secret::rand(&mut OsRng);
+            private_key
+                .serialize_uncompressed(&mut buffer)
+                .map_err(|_| {
+                    Error::BlsBn254("Secret serialization failed during generation".to_string())
+                })?;
+            let secret = hex::encode(buffer);
+            Ok(Secret::from_le_bytes_mod_order(secret.as_bytes()))
         }
     }
 }
 
 pub fn sign(secret: &mut Secret, msg: &[u8; 32]) -> Signature {
-    let hashed_point = map_to_curve(msg);
-    let sig = hashed_point.mul_bigint(secret.0);
-    Signature::from(sig)
+    let pair = BlsKeyPair::new(secret.to_string()).unwrap();
+    pair.sign_message(msg.as_slice()).g1_point().g1()
 }
 
 #[must_use]

--- a/sdk/src/keystore/mod.rs
+++ b/sdk/src/keystore/mod.rs
@@ -43,6 +43,8 @@ pub mod error;
 
 /// Schnorrkel Support
 pub mod sr25519;
+#[cfg(test)]
+mod tests;
 
 use crate::clients::tangle::runtime::TangleConfig;
 #[cfg(any(feature = "std", feature = "wasm"))]
@@ -414,37 +416,3 @@ pub trait KeystoreUriSanitizer: AsRef<Path> {
 }
 
 impl<T: AsRef<Path>> KeystoreUriSanitizer for T {}
-
-#[cfg(test)]
-mod tests {
-    use crate::keystore::KeystoreUriSanitizer;
-    use std::path::PathBuf;
-
-    #[test]
-    fn test_sanitize_file_paths() {
-        let path = "file:///tmp/keystore";
-        let sanitized_path = path.sanitize_file_path();
-        assert_eq!(sanitized_path, PathBuf::from("/tmp/keystore"));
-    }
-
-    #[test]
-    fn test_sanitize_file_paths_with_single_slash() {
-        let path = "file:/tmp/keystore";
-        let sanitized_path = path.sanitize_file_path();
-        assert_eq!(sanitized_path, PathBuf::from("/tmp/keystore"));
-    }
-
-    #[test]
-    fn test_sanitize_file_paths_with_double_slash() {
-        let path = "file://tmp/keystore";
-        let sanitized_path = path.sanitize_file_path();
-        assert_eq!(sanitized_path, PathBuf::from("/tmp/keystore"));
-    }
-
-    #[test]
-    fn test_sanitize_file_paths_with_no_scheme() {
-        let path = "/tmp/keystore";
-        let sanitized_path = path.sanitize_file_path();
-        assert_eq!(sanitized_path, PathBuf::from("/tmp/keystore"));
-    }
-}

--- a/sdk/src/keystore/mod.rs
+++ b/sdk/src/keystore/mod.rs
@@ -267,6 +267,13 @@ pub trait Backend {
     /// # Errors
     /// An `Err` will be returned if generating the key pair operation itself failed.
     fn bls_bn254_generate_new(&self, seed: Option<&[u8]>) -> Result<bn254::Public, Error>;
+    /// Generate a new bls bn254 key pair from a [`bn254::Secret`] hex String
+    ///
+    /// Returns an [`bn254::Public`] key of the generated key pair or an `Err` if
+    /// something failed during key generation.
+    /// # Errors
+    /// An `Err` will be returned if generating the key pair operation itself failed.
+    fn bls_bn254_generate_from_secret(&self, secret: String) -> Result<bn254::Public, Error>;
     /// Generate a bls bn254 signature for a given message.
     ///
     /// Receives an [`bn254::Public`] key to be able to map
@@ -384,8 +391,7 @@ pub trait BackendExt: Backend {
         let bls_secret = self
             .expose_bls_bn254_secret(&first_key)?
             .ok_or_else(|| Error::BlsBn254("No BLS BN254 secret found".to_string()))?;
-
-        crypto_bls::BlsKeyPair::new(bls_secret.0.to_string())
+        crypto_bls::BlsKeyPair::new(bls_secret.to_string())
             .map_err(|e| Error::BlsBn254(e.to_string()))
     }
 }

--- a/sdk/src/keystore/mod.rs
+++ b/sdk/src/keystore/mod.rs
@@ -227,6 +227,13 @@ pub trait Backend {
     /// # Errors
     /// An `Err` will be returned if generating the key pair operation itself failed.
     fn ecdsa_generate_new(&self, seed: Option<&[u8]>) -> Result<ecdsa::Public, Error>;
+    /// Generate a new ecdsa key pair from a [`ecdsa::Secret`] hex String
+    ///
+    /// Returns an `ecdsa::Public` key of the generated key pair or an `Err` if
+    /// something failed during key generation.
+    /// # Errors
+    /// An `Err` will be returned if generating the key pair operation itself failed.
+    fn ecdsa_generate_from_string(&self, string: &str) -> Result<ecdsa::Public, Error>;
     /// Generate an ecdsa signature for a given message.
     ///
     /// Receives an [`ecdsa::Public`] key to be able to map
@@ -275,7 +282,7 @@ pub trait Backend {
     /// something failed during key generation.
     /// # Errors
     /// An `Err` will be returned if generating the key pair operation itself failed.
-    fn bls_bn254_generate_from_secret(&self, secret: String) -> Result<bn254::Public, Error>;
+    fn bls_bn254_generate_from_string(&self, secret: String) -> Result<bn254::Public, Error>;
     /// Generate a bls bn254 signature for a given message.
     ///
     /// Receives an [`bn254::Public`] key to be able to map
@@ -301,6 +308,7 @@ pub trait Backend {
     /// # Errors
     /// An `Err` will be returned if finding the key operation itself failed.
     fn expose_ecdsa_secret(&self, public: &ecdsa::Public) -> Result<Option<ecdsa::Secret>, Error>;
+    fn get_ecdsa_signer_string(&self, public: &k256::PublicKey) -> Result<String, Error>;
     /// Returns the [`ed25519::Secret`] for the given [`ed25519::Public`] if it does exist, otherwise returns `None`.
     /// # Errors
     /// An `Err` will be returned if finding the key operation itself failed.

--- a/sdk/src/keystore/sr25519.rs
+++ b/sdk/src/keystore/sr25519.rs
@@ -5,7 +5,7 @@ pub use schnorrkel::SecretKey as Secret;
 pub use schnorrkel::Signature;
 
 /// The context used for signing.
-const SIGNING_CTX: &[u8] = b"substrate";
+pub(crate) const SIGNING_CTX: &[u8] = b"substrate";
 
 /// Sign a message with the given secret key.
 ///

--- a/sdk/src/keystore/tests.rs
+++ b/sdk/src/keystore/tests.rs
@@ -89,7 +89,7 @@ mod sr25519 {
     }
 
     #[test]
-    #[cfg(all(feature = "getrandom"))]
+    #[cfg(feature = "getrandom")]
     fn signature() {
         let keystore = setup_mem_test_keystore();
         let public = keystore
@@ -152,7 +152,7 @@ mod ed25519 {
     }
 
     #[test]
-    #[cfg(all(feature = "getrandom"))]
+    #[cfg(feature = "getrandom")]
     fn signature() {
         let keystore = setup_mem_test_keystore();
         let public = keystore
@@ -215,7 +215,7 @@ mod ecdsa {
     }
 
     #[test]
-    #[cfg(all(feature = "getrandom"))]
+    #[cfg(feature = "getrandom")]
     fn signature() {
         let keystore = setup_mem_test_keystore();
         let public = keystore
@@ -294,7 +294,7 @@ mod bls381 {
     }
 
     #[test]
-    #[cfg(all(feature = "getrandom"))]
+    #[cfg(feature = "getrandom")]
     fn signature() {
         let keystore = setup_mem_test_keystore();
         let public = keystore
@@ -369,7 +369,7 @@ mod bn254 {
     }
 
     #[test]
-    #[cfg(all(feature = "getrandom"))]
+    #[cfg(feature = "getrandom")]
     fn signature() {
         let keystore = setup_mem_test_keystore();
         let public = keystore

--- a/sdk/src/keystore/tests.rs
+++ b/sdk/src/keystore/tests.rs
@@ -1,0 +1,400 @@
+#![allow(dead_code, unused_imports)]
+use crate::keystore::backend::fs::FilesystemKeystore;
+use crate::keystore::backend::mem::InMemoryKeystore;
+use crate::keystore::Backend;
+use crate::keystore::KeystoreUriSanitizer;
+use parking_lot::RawRwLock;
+use std::path::PathBuf;
+
+const KEYSTORE_PATH: &str = "./test_keys";
+
+fn setup_mem_test_keystore() -> InMemoryKeystore<RawRwLock> {
+    InMemoryKeystore::new()
+}
+
+fn setup_fs_test_keystore(key_type: &str) -> (FilesystemKeystore, String) {
+    let key_path = format!("{KEYSTORE_PATH}-{key_type}");
+    (
+        FilesystemKeystore::open(key_path.clone()).unwrap(),
+        key_path,
+    )
+}
+
+#[test]
+fn test_sanitize_file_paths() {
+    let path = "file:///tmp/keystore";
+    let sanitized_path = path.sanitize_file_path();
+    assert_eq!(sanitized_path, PathBuf::from("/tmp/keystore"));
+}
+
+#[test]
+fn test_sanitize_file_paths_with_single_slash() {
+    let path = "file:/tmp/keystore";
+    let sanitized_path = path.sanitize_file_path();
+    assert_eq!(sanitized_path, PathBuf::from("/tmp/keystore"));
+}
+
+#[test]
+fn test_sanitize_file_paths_with_double_slash() {
+    let path = "file://tmp/keystore";
+    let sanitized_path = path.sanitize_file_path();
+    assert_eq!(sanitized_path, PathBuf::from("/tmp/keystore"));
+}
+
+#[test]
+fn test_sanitize_file_paths_with_no_scheme() {
+    let path = "/tmp/keystore";
+    let sanitized_path = path.sanitize_file_path();
+    assert_eq!(sanitized_path, PathBuf::from("/tmp/keystore"));
+}
+
+mod sr25519 {
+    use super::*;
+    use crate::keystore::sr25519::SIGNING_CTX;
+    use crate::keystore::BackendExt;
+    use schnorrkel::Keypair;
+    use sp_core::Pair;
+
+    #[test]
+    #[cfg(all(feature = "getrandom", feature = "std"))]
+    fn keys() {
+        // In-Memory
+        let mem_keystore = setup_mem_test_keystore();
+        let mem_public = mem_keystore
+            .sr25519_generate_new(None)
+            .expect("Should generate key");
+        // Read back the key from in-memory storage
+        let mem_read = mem_keystore.sr25519_key().expect("Should read keys");
+        assert_eq!(
+            mem_public.to_bytes(),
+            mem_read.public().0,
+            "In-memory key should not be mutated in storage"
+        );
+
+        // Filesystem
+        let (fs_keystore, path) = setup_fs_test_keystore("sr25519");
+        let fs_public = fs_keystore
+            .sr25519_generate_new(None)
+            .expect("Should generate key");
+        // Read back the key from filesystem storage
+        let fs_read = fs_keystore.sr25519_key().expect("Should read keys");
+        assert_eq!(
+            fs_public.to_bytes(),
+            fs_read.public().0,
+            "Filesystem key should not be mutated in storage"
+        );
+
+        // Clean up filesystem keystore
+        std::fs::remove_dir_all(path).expect("Failed to clean up test directory");
+    }
+
+    #[test]
+    #[cfg(all(feature = "getrandom"))]
+    fn signature() {
+        let keystore = setup_mem_test_keystore();
+        let public = keystore
+            .sr25519_generate_new(None)
+            .expect("Should generate key");
+        let secret = keystore.expose_sr25519_secret(&public).unwrap().unwrap();
+        let pair = Keypair { secret, public };
+        let msg = b"test message";
+        let sig = keystore
+            .sr25519_sign(&public, msg)
+            .expect("Should sign")
+            .expect("Should have signature");
+        let ctx = schnorrkel::signing_context(SIGNING_CTX);
+
+        // Verify with correct message
+        assert!(pair.public.verify(ctx.bytes(msg), &sig).is_ok());
+        // Try to verify with wrong message
+        let wrong_msg = b"wrong message";
+        assert!(pair.public.verify(ctx.bytes(wrong_msg), &sig).is_err());
+    }
+}
+
+mod ed25519 {
+    use super::*;
+    use crate::keystore::ed25519::Public;
+    use crate::keystore::BackendExt;
+    use sp_core::Pair;
+
+    #[test]
+    #[cfg(all(feature = "getrandom", feature = "std"))]
+    fn keys() {
+        // In-Memory
+        let mem_keystore = setup_mem_test_keystore();
+        let mem_public = mem_keystore
+            .ed25519_generate_new(None)
+            .expect("Should generate key");
+        // Read back the key from in-memory storage
+        let mem_read = mem_keystore.ed25519_key().expect("Should read keys");
+        assert_eq!(
+            mem_public.as_ref(),
+            mem_read.public().0.as_ref(),
+            "In-memory key should not be mutated in storage"
+        );
+
+        // Filesystem
+        let (fs_keystore, path) = setup_fs_test_keystore("ed25519");
+        let fs_public = fs_keystore
+            .ed25519_generate_new(None)
+            .expect("Should generate key");
+        // Read back the key from filesystem storage
+        let fs_read = fs_keystore.ed25519_key().expect("Should read keys");
+        assert_eq!(
+            fs_public.as_ref(),
+            fs_read.public().0.as_ref(),
+            "Filesystem key should not be mutated in storage"
+        );
+
+        // Clean up filesystem keystore
+        std::fs::remove_dir_all(path).expect("Failed to clean up test directory");
+    }
+
+    #[test]
+    #[cfg(all(feature = "getrandom"))]
+    fn signature() {
+        let keystore = setup_mem_test_keystore();
+        let public = keystore
+            .ed25519_generate_new(None)
+            .expect("Should generate key");
+        let secret = keystore.expose_ed25519_secret(&public).unwrap().unwrap();
+        let verification_key = Public::from(&secret);
+        let msg = b"test message";
+        let sig = keystore
+            .ed25519_sign(&public, msg)
+            .expect("Should sign")
+            .expect("Should have signature");
+
+        // Verify with correct message
+        assert!(verification_key.verify(&sig, msg).is_ok());
+
+        // Try to verify with wrong message
+        let wrong_msg = b"wrong message";
+        assert!(verification_key.verify(&sig, wrong_msg).is_err());
+    }
+}
+
+mod ecdsa {
+    use super::*;
+    use crate::keystore::BackendExt;
+    use k256::ecdsa::signature::Verifier;
+    use sp_core::Pair;
+
+    #[test]
+    #[cfg(all(feature = "getrandom", feature = "std"))]
+    fn keys() {
+        // In-Memory
+        let mem_keystore = setup_mem_test_keystore();
+        let mem_public = mem_keystore
+            .ecdsa_generate_new(None)
+            .expect("Should generate key");
+        // Read back the key from in-memory storage
+        let mem_read = mem_keystore.ecdsa_key().expect("Should read keys");
+        assert_eq!(
+            mem_public.to_sec1_bytes().as_ref(),
+            mem_read.public().0,
+            "In-memory key should not be mutated in storage"
+        );
+
+        // Filesystem
+        let (fs_keystore, path) = setup_fs_test_keystore("ecdsa");
+        let fs_public = fs_keystore
+            .ecdsa_generate_new(None)
+            .expect("Should generate key");
+        // Read back the key from filesystem storage
+        let fs_read = fs_keystore.ecdsa_key().expect("Should read keys");
+        assert_eq!(
+            fs_public.to_sec1_bytes().as_ref(),
+            fs_read.public().0,
+            "Filesystem key should not be mutated in storage"
+        );
+
+        // Clean up filesystem keystore
+        std::fs::remove_dir_all(path).expect("Failed to clean up test directory");
+    }
+
+    #[test]
+    #[cfg(all(feature = "getrandom"))]
+    fn signature() {
+        let keystore = setup_mem_test_keystore();
+        let public = keystore
+            .ecdsa_generate_new(None)
+            .expect("Should generate key");
+        let msg = b"test message";
+        let sig = keystore
+            .ecdsa_sign(&public, msg)
+            .expect("Should sign")
+            .expect("Should have signature");
+
+        // Convert public key to k256::ecdsa::VerifyingKey
+        let verifying_key =
+            k256::ecdsa::VerifyingKey::from_sec1_bytes(public.to_sec1_bytes().as_ref())
+                .expect("Should create verifying key");
+
+        // Verify with correct message
+        assert!(
+            verifying_key.verify(msg, &sig).is_ok(),
+            "Signature verification failed"
+        );
+
+        // Try to verify with wrong message
+        let wrong_msg = b"wrong message";
+        assert!(
+            verifying_key.verify(wrong_msg, &sig).is_err(),
+            "Signature should not verify with wrong message"
+        );
+
+        // Try to verify with wrong public key
+        let wrong_public = keystore
+            .ecdsa_generate_new(None)
+            .expect("Should generate key");
+        let wrong_verifying_key =
+            k256::ecdsa::VerifyingKey::from_sec1_bytes(wrong_public.to_sec1_bytes().as_ref())
+                .expect("Should create wrong verifying key");
+        assert!(
+            wrong_verifying_key.verify(msg, &sig).is_err(),
+            "Signature should not verify with wrong public key"
+        );
+    }
+}
+
+mod bls381 {
+    use super::*;
+
+    #[test]
+    #[cfg(all(feature = "getrandom", feature = "std"))]
+    fn keys() {
+        // In-Memory
+        let mem_keystore = setup_mem_test_keystore();
+        let mem_public = mem_keystore
+            .bls381_generate_new(None)
+            .expect("Should generate key");
+        // Read back the key from in-memory storage
+        let mem_read = mem_keystore.iter_bls381().next().unwrap();
+        assert_eq!(
+            mem_public.0, mem_read.0,
+            "In-memory key should not be mutated in storage"
+        );
+
+        // Filesystem
+        let (fs_keystore, path) = setup_fs_test_keystore("bls381");
+        let fs_public = fs_keystore
+            .bls381_generate_new(None)
+            .expect("Should generate key");
+        // Read back the key from filesystem storage
+        let fs_read = fs_keystore.iter_bls381().next().unwrap();
+        assert_eq!(
+            fs_public.0, fs_read.0,
+            "Filesystem key should not be mutated in storage"
+        );
+
+        // Clean up filesystem keystore
+        std::fs::remove_dir_all(path).expect("Failed to clean up test directory");
+    }
+
+    #[test]
+    #[cfg(all(feature = "getrandom"))]
+    fn signature() {
+        let keystore = setup_mem_test_keystore();
+        let public = keystore
+            .bls381_generate_new(None)
+            .expect("Should generate key");
+        let msg = b"test message";
+        let sig = keystore
+            .bls381_sign(&public, msg)
+            .expect("Should sign")
+            .expect("Should have signature");
+
+        // Verify with correct message
+        assert!(
+            sig.verify(&w3f_bls::Message::from(msg.as_slice()), &public),
+            "Signature verification failed"
+        );
+
+        // Try to verify with wrong message
+        let wrong_msg = b"wrong message";
+        assert!(
+            !sig.verify(&w3f_bls::Message::from(wrong_msg.as_slice()), &public),
+            "Signature should not verify with wrong message"
+        );
+
+        // Try to verify with wrong public key
+        let wrong_public = keystore
+            .bls381_generate_new(None)
+            .expect("Should generate key");
+        assert!(
+            !sig.verify(&w3f_bls::Message::from(msg.as_slice()), &wrong_public),
+            "Signature should not verify with wrong public key"
+        );
+    }
+}
+
+mod bn254 {
+    use super::*;
+    use crate::keystore::BackendExt;
+    use eigensdk::crypto_bn254::utils::verify_message;
+
+    #[test]
+    #[cfg(all(feature = "getrandom", feature = "std"))]
+    fn keys() {
+        // In-Memory
+        let mem_keystore = setup_mem_test_keystore();
+        let mem_public = mem_keystore
+            .bls_bn254_generate_new(None)
+            .expect("Should generate key");
+        // Read back the key from in-memory storage
+        let mem_read = mem_keystore.bls_bn254_key().expect("Should read keys");
+        assert_eq!(
+            mem_public,
+            mem_read.public_key(),
+            "In-memory key should not be mutated in storage"
+        );
+
+        // Filesystem
+        let (fs_keystore, path) = setup_fs_test_keystore("bn254");
+        let fs_public = fs_keystore
+            .bls_bn254_generate_new(None)
+            .expect("Should generate key");
+        // Read back the key from filesystem storage
+        let fs_read = fs_keystore.bls_bn254_key().expect("Should read keys");
+        assert_eq!(
+            fs_public,
+            fs_read.public_key(),
+            "Filesystem key should not be mutated in storage"
+        );
+
+        // Clean up filesystem keystore
+        std::fs::remove_dir_all(path).expect("Failed to clean up test directory");
+    }
+
+    #[test]
+    #[cfg(all(feature = "getrandom"))]
+    fn signature() {
+        let keystore = setup_mem_test_keystore();
+        let public = keystore
+            .bls_bn254_generate_new(None)
+            .expect("Should generate key");
+        let msg: &[u8; 32] = b"testing messages testing message";
+        let sig = keystore
+            .bls_bn254_sign(&public, msg)
+            .expect("Should sign")
+            .expect("Should have signature");
+        let pair = keystore.bls_bn254_key().unwrap();
+
+        assert_eq!(public.g1(), pair.public_key().g1());
+
+        // Verify with correct message
+        assert!(
+            verify_message(pair.public_key_g2().g2(), msg, sig),
+            "Signature verification failed"
+        );
+
+        // Try to verify with wrong message
+        let wrong_msg = b"wrong message";
+        assert!(
+            !verify_message(pair.public_key_g2().g2(), wrong_msg, sig),
+            "Signature should not verify with wrong message"
+        );
+    }
+}

--- a/sdk/src/keystore/tests.rs
+++ b/sdk/src/keystore/tests.rs
@@ -183,6 +183,52 @@ mod ecdsa {
 
     #[test]
     #[cfg(all(feature = "getrandom", feature = "std"))]
+    fn alloy_key() {
+        let private_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+        // In-Memory
+        let mem_keystore = setup_mem_test_keystore();
+        let mem_public = mem_keystore
+            .ecdsa_generate_from_string(private_key)
+            .expect("Should generate key");
+        let read_secret = mem_keystore.get_ecdsa_signer_string(&mem_public).unwrap();
+        assert_eq!(
+            private_key, read_secret,
+            "Private Key string should not be mutated in storage"
+        );
+
+        // Read back the key from in-memory storage
+        let mem_read = mem_keystore.ecdsa_key().expect("Should read keys");
+        assert_eq!(
+            mem_public.to_sec1_bytes().as_ref(),
+            mem_read.public().0,
+            "In-memory key should not be mutated in storage"
+        );
+
+        // Filesystem
+        let (fs_keystore, path) = setup_fs_test_keystore("ecdsa");
+        let fs_public = fs_keystore
+            .ecdsa_generate_from_string(private_key)
+            .expect("Should generate key");
+        let read_secret = fs_keystore.get_ecdsa_signer_string(&fs_public).unwrap();
+        assert_eq!(
+            private_key, read_secret,
+            "Private Key string should not be mutated in storage"
+        );
+
+        // Read back the key from filesystem storage
+        let fs_read = fs_keystore.ecdsa_key().expect("Should read keys");
+        assert_eq!(
+            fs_public.to_sec1_bytes().as_ref(),
+            fs_read.public().0,
+            "Filesystem key should not be mutated in storage"
+        );
+
+        // Clean up filesystem keystore
+        std::fs::remove_dir_all(path).expect("Failed to clean up test directory");
+    }
+
+    #[test]
+    #[cfg(all(feature = "getrandom", feature = "std"))]
     fn keys() {
         // In-Memory
         let mem_keystore = setup_mem_test_keystore();


### PR DESCRIPTION
## Overview

Addresses/adds the following:
- Support for EigenLayer keys i.e., BLS BN254
- Fixes for BLS BN254, and BLS381
- Tests for all keystore types and key types