### PR TITLE
ci: downgrade and pin release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@v0.5
+        uses: MarcoIeni/release-plz-action@91356927c5ac06a27d9342861ff6e234210d56b4 # v0.5.71
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/release-plz.yml` file. The change updates the `MarcoIeni/release-plz-action` to a specific commit hash for better version control.

* Updated the `MarcoIeni/release-plz-action` to use a specific commit hash `91356927c5ac06a27d9342861ff6e234210d56b4` instead of the version tag `v0.5`. (`.github/workflows/release-plz.yml`)

Related to this comment: https://github.com/MarcoIeni/release-plz/issues/1791#issuecomment-2432360669