### PR TITLE
chore: release crates manually to unblock release-plz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-metadata"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "cargo_metadata",
  "fs2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,9 +52,9 @@ incredible-squaring-blueprint-eigenlayer = { path = "./blueprints/incredible-squ
 incredible-squaring-aggregator = { path = "./blueprints/incredible-squaring-eigenlayer/aggregator", default-features = false, version = "0.1.1" }
 periodic-web-poller-blueprint = { path = "./blueprints/periodic-web-poller", default-features = false, version = "0.1.1" }
 gadget-blueprint-proc-macro = { path = "./macros/blueprint-proc-macro", default-features = false, version = "0.2.0" }
-gadget-blueprint-proc-macro-core = { path = "./macros/blueprint-proc-macro-core", default-features = false, version = "0.1.2" }
+gadget-blueprint-proc-macro-core = { path = "./macros/blueprint-proc-macro-core", default-features = false, version = "0.1.3" }
 gadget-context-derive = { path = "./macros/context-derive", default-features = false, version = "0.1.1" }
-blueprint-metadata = { path = "./blueprint-metadata", default-features = false, version = "0.1.3" }
+blueprint-metadata = { path = "./blueprint-metadata", default-features = false, version = "0.1.4" }
 cargo-tangle = { path = "./cli", version = "0.1.3" }
 cargo_metadata = { version = "0.18.1" }
 

--- a/blueprint-metadata/Cargo.toml
+++ b/blueprint-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-metadata"
-version = "0.1.3"
+version = "0.1.4"
 description = "A build dependency for generating metadata for Blueprint at compile time."
 authors.workspace = true
 edition.workspace = true

--- a/macros/blueprint-proc-macro/src/job.rs
+++ b/macros/blueprint-proc-macro/src/job.rs
@@ -764,7 +764,6 @@ impl Parse for Results {
     }
 }
 
-#[derive(Debug)]
 /// `#[job(event_listener(MyCustomListener, MyCustomListener2)]`
 /// Accepts an optional argument that specifies the event listener to use that implements EventListener
 pub(crate) struct EventListenerArgs {
@@ -778,7 +777,6 @@ pub enum ListenerType {
     Custom,
 }
 
-#[derive(Debug)]
 pub(crate) struct SingleListener {
     pub listener: Type,
     pub evm_args: Option<EvmArgs>,
@@ -890,7 +888,6 @@ impl Parse for EventListenerArgs {
     }
 }
 
-#[derive(Debug)]
 pub(crate) struct EvmArgs {
     instance: Option<Ident>,
     event: Option<Type>,


### PR DESCRIPTION
This pull request makes several changes to the `macros/blueprint-proc-macro/src/job.rs` file to clean up the code by removing unnecessary `#[derive(Debug)]` annotations. The most important changes include:

Code cleanup:

* `impl Parse for Results` in `macros/blueprint-proc-macro/src/job.rs`: Removed the `#[derive(Debug)]` annotation from the `EventListenerArgs` struct.
* `pub enum ListenerType` in `macros/blueprint-proc-macro/src/job.rs`: Removed the `#[derive(Debug)]` annotation from the `SingleListener` struct.
* `impl Parse for EventListenerArgs` in `macros/blueprint-proc-macro/src/job.rs`: Removed the `#[derive(Debug)]` annotation from the `EvmArgs` struct.