### PR TITLE
feat(cargo-tangle)!: rename "gadget" to "blueprint"

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cargo install cargo-tangle --git https://github.com/tangle-network/gadget --forc
 To create a new blueprint/gadget using the Tangle CLI:
 
 ```bash
-cargo tangle gadget create --name <blueprint_name>
+cargo tangle blueprint create --name <blueprint_name>
 ```
 
 ### Deploying a Blueprint
@@ -62,7 +62,7 @@ Finally, the blueprint can be deployed to a local Tangle node using the followin
 ```bash
 export SIGNER="//Alice" # Substrate Signer account
 export EVM_SIGNER="0xcb6df9de1efca7a3998a8ead4e02159d5fa99c3e0d4fd6432667390bb4726854" # EVM signer account
-cargo tangle gadget deploy --rpc-url <rpc_url> --package <package_name>
+cargo tangle blueprint deploy --rpc-url <rpc_url> --package <package_name>
 ```
 
 More information on this process can be found in the [CLI documentation](./cli/README.md)
@@ -83,7 +83,7 @@ cargo test --package blueprint-test-utils tests_standard::test_externalities_gad
 Since testing is in beta stage, each time the blueprint is run, you
 must cancel the testnet and restart it to ensure storage is reset.
 All these nuances and manual requirement of setting up a testnet will be resolved in the near future and will be
-testable via `cargo tangle gadget test`
+testable via `cargo tangle blueprint test`
 
 ## License
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -13,7 +13,9 @@ Create and Deploy blueprints on Tangle Network.
 
 ## Overview
 
-The Tangle CLI is a command-line tool that allows you to create and deploy blueprints/gadgets on the Tangle network. It provides a simple and efficient way to manage your blueprints and gadgets, making it easy to get started with Tangle Blueprints.
+The Tangle CLI is a command-line tool that allows you to create and deploy blueprints/gadgets on the Tangle network. It
+provides a simple and efficient way to manage your blueprints and gadgets, making it easy to get started with Tangle
+Blueprints.
 
 ## Installation
 
@@ -36,7 +38,7 @@ cargo install cargo-tangle --git https://github.com/tangle-network/gadget --forc
 To create a new blueprint/gadget using the Tangle CLI, use the following command:
 
 ```bash
-cargo tangle gadget create --name <blueprint_name>
+cargo tangle blueprint create --name <blueprint_name>
 ```
 
 Replace `<blueprint_name>` with the desired name for your blueprint.
@@ -44,7 +46,7 @@ Replace `<blueprint_name>` with the desired name for your blueprint.
 ### Example
 
 ```bash
-cargo tangle gadget create --name my_blueprint
+cargo tangle blueprint create --name my_blueprint
 ```
 
 ## Build The Blueprint and the Gadget
@@ -70,15 +72,16 @@ To deploy the blueprint to a local Tangle node, use the following command:
 ```bash
 export SIGNER="//Alice" # Substrate Signer account
 export EVM_SIGNER="0xcb6df9de1efca7a3998a8ead4e02159d5fa99c3e0d4fd6432667390bb4726854" # EVM signer account
-cargo tangle gadget deploy --rpc-url <rpc_url> --package <package_name>
+cargo tangle blueprint deploy --rpc-url <rpc_url> --package <package_name>
 ```
 
-Replace `<rpc_url>` with the RPC URL of your local Tangle node and `<package_name>` with the name of the package to deploy.
+Replace `<rpc_url>` with the RPC URL of your local Tangle node and `<package_name>` with the name of the package to
+deploy.
 
 ### Example
 
 ```bash
-cargo tangle gadget deploy --rpc-url ws://localhost:9944 --package my_blueprint
+cargo tangle blueprint deploy --rpc-url ws://localhost:9944 --package my_blueprint
 ```
 
 Expected output:

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -22,8 +22,9 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Commands {
-    /// Gadget subcommand
-    Gadget {
+    /// Blueprint subcommand
+    #[command(visible_alias = "bp")]
+    Blueprint {
         #[command(subcommand)]
         subcommand: GadgetCommands,
     },
@@ -32,6 +33,7 @@ enum Commands {
 #[derive(Subcommand, Debug)]
 enum GadgetCommands {
     /// Create a new blueprint
+    #[command(visible_alias = "c")]
     Create {
         /// The name of the blueprint
         #[arg(short, long)]
@@ -42,6 +44,7 @@ enum GadgetCommands {
     },
 
     /// Deploy a blueprint to the Tangle Network.
+    #[command(visible_alias = "d")]
     Deploy {
         /// Tangle RPC URL to use
         #[arg(long, value_name = "URL", default_value = "wss://rpc.tangle.tools")]
@@ -73,7 +76,7 @@ async fn main() -> color_eyre::Result<()> {
     let cli = Cli::parse_from(args);
 
     match cli.command {
-        Commands::Gadget { subcommand } => match subcommand {
+        Commands::Blueprint { subcommand } => match subcommand {
             GadgetCommands::Create { name, source } => {
                 create::new_blueprint(name, source);
             }


### PR DESCRIPTION
Also added "bp" as an alias since blueprint is a long word.

closes #353