### PR TITLE
fix(blueprints): remove blueprint metadata from eigen blueprint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6018,7 +6018,6 @@ dependencies = [
  "ark-ff 0.4.2",
  "async-trait",
  "bip39",
- "blueprint-metadata",
  "blueprint-test-utils",
  "color-eyre",
  "ed25519-zebra 4.0.3",

--- a/blueprints/incredible-squaring-eigenlayer/Cargo.toml
+++ b/blueprints/incredible-squaring-eigenlayer/Cargo.toml
@@ -56,9 +56,6 @@ blueprint-test-utils = { workspace = true }
 incredible-squaring-aggregator = { workspace = true }
 gadget-io = { workspace = true }
 
-[build-dependencies]
-blueprint-metadata = { workspace = true }
-
 [features]
 default = ["std"]
 std = []

--- a/blueprints/incredible-squaring-eigenlayer/build.rs
+++ b/blueprints/incredible-squaring-eigenlayer/build.rs
@@ -6,7 +6,6 @@ fn main() {
     println!("cargo:rerun-if-changed=src/cli");
     println!("cargo:rerun-if-changed=src/lib.rs");
     println!("cargo:rerun-if-changed=src/main.rs");
-    blueprint_metadata::generate_json();
 
     let contract_dirs: Vec<&str> = vec![
         "./contracts/lib/eigenlayer-middleware/lib/eigenlayer-contracts",


### PR DESCRIPTION
## Overview

Blueprint Metadata is not needed for the Eigenlayer Blueprints and is causing issues in the build script. This PR removes it from the incredible-squaring-eigenlayer blueprint.