### PR TITLE
feat(ci): add some commit parsers to release-plz

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,3 +2,27 @@
 allow_dirty = true         # allow updating repositories with uncommitted changes
 publish_allow_dirty = true # add `--allow-dirty` to `cargo publish`
 publish_timeout = "10m"    # set a timeout for `cargo publish`
+
+commit_preprocessors = [
+    # Allow shortened crate names
+    { pattern = '^(\w+!?)\(sdk\):', replace = "$1(gadget-sdk):" },
+    { pattern = '^(\w+!?)\(cli\):', replace = "$1(cargo-tangle):" },
+]
+
+commit_parsers = [
+    { message = "^feat", group = "added" },
+    { message = "^changed", group = "changed" },
+    { message = "^deprecated", group = "deprecated" },
+    { message = "^fix", group = "fixed" },
+    { message = "^security", group = "security" },
+    { message = "^.*", group = "other" },
+    # Ignore CI commits
+    { message = "^\\w+!?\\(ci\\)", skip = true },
+    # Ignore Clippy commits
+    { message = "^chore\\(clippy\\)", skip = true },
+    { message = "^chore(?:\\(([^)]+)\\))?: clippy", skip = true },
+    # Ignore any formatting commits
+    { message = "^chore(?:\\(([^)]+)\\))?: fmt", skip = true },
+    # Ignore dependency commits
+    { message = "^chore\\(deps.*\\)", skip = true },
+]


### PR DESCRIPTION
Part of #372

This comes with some new rules for our commit messages.

## New commit rules

For commits we don't want getting into changelogs.

* CI changes
	* Use a scope of "ci": `feat(ci): ...`
* Clippy fixes
	* Use a scope or description of "clippy":
		* `chore(clippy): ...`
		* `chore: clippy`
		* `chore(sdk): clippy`
* Formatting fixes
	* Use a description of "fmt": `chore: fmt` or `chore(sdk): fmt`
* Dependency changes
	* Use a scope of "deps": `chore(deps): ...`

## Other general rules

* Using conventional commits in general
	* This even applies to squashed commits
* Correctly marking things as breaking: `feat!:` vs `feat:`
* Splitting up our PRs
	* At the moment, a lot of the PRs end up touching things outside of their scope.
* **Adding scopes to commit messages**