### PR TITLE
fix(blueprint-proc-macro): resolve dependency cycle with gadget-sdk

### DIFF
--- a/macros/blueprint-proc-macro/Cargo.toml
+++ b/macros/blueprint-proc-macro/Cargo.toml
@@ -22,7 +22,7 @@ indexmap = { workspace = true }
 
 [dev-dependencies]
 trybuild = { workspace = true }
-gadget-sdk = { workspace = true, features = ["std"] }
+gadget-sdk = { path = "../../sdk", features = ["std"] }
 tracing = { workspace = true }
 async-trait = { workspace = true }
 


### PR DESCRIPTION
Looks like if you just use a path dependency (or a dependency in any way that doesn't specify a version), then it'll just get dropped from the manifest when publishing.

closes #388