### PR TITLE
fix(sdk)!: allow for zero-based `blueprint_id`

### DIFF
--- a/blueprint-manager/src/executor/event_handler.rs
+++ b/blueprint-manager/src/executor/event_handler.rs
@@ -35,8 +35,8 @@ impl Debug for VerifiedBlueprint<'_> {
     }
 }
 
-pub async fn handle_services<'a>(
-    blueprints: &[VerifiedBlueprint<'a>],
+pub async fn handle_services(
+    blueprints: &[VerifiedBlueprint<'_>],
     gadget_config: &GadgetConfig,
     blueprint_manager_opts: &BlueprintManagerConfig,
     active_gadgets: &mut ActiveGadgets,

--- a/blueprint-manager/src/sources/mod.rs
+++ b/blueprint-manager/src/sources/mod.rs
@@ -19,8 +19,8 @@ pub trait BinarySourceFetcher: Send + Sync {
     fn name(&self) -> String;
 }
 
-pub async fn handle<'a>(
-    blueprint: &VerifiedBlueprint<'a>,
+pub async fn handle(
+    blueprint: &VerifiedBlueprint<'_>,
     gadget_config: &GadgetConfig,
     blueprint_manager_opts: &BlueprintManagerConfig,
     active_gadgets: &mut ActiveGadgets,

--- a/macros/context-derive/src/services.rs
+++ b/macros/context-derive/src/services.rs
@@ -94,13 +94,17 @@ pub fn generate_context_impl(
                         gadget_sdk::config::ProtocolSpecificSettings::Tangle(settings) => settings.service_id,
                         _ => return Err(subxt::Error::Other("Service instance id is only available for Tangle protocol".to_string())),
                     };
-                    let service_instance = api::storage().services().instances(service_instance_id);
+                    let service_id = match service_instance_id {
+                      Some(service_instance_id) => service_instance_id,
+                      None => return Err(subxt::Error::Other("Service instance id is not set. Running in Registration mode?".to_string())),
+                    };
+                    let service_instance = api::storage().services().instances(service_id);
                     let storage = client.storage().at_latest().await?;
                     let result = storage.fetch(&service_instance).await?;
                     match result {
                         Some(instance) => Ok(instance.operators.0),
                         None => Err(subxt::Error::Other(format!(
-                            "Service instance {service_instance_id} is not created, yet"
+                            "Service instance {service_id} is not created, yet"
                         ))),
                     }
                 }

--- a/sdk/src/config/gadget_config.rs
+++ b/sdk/src/config/gadget_config.rs
@@ -108,7 +108,7 @@ impl<RwLock: lock_api::RawRwLock> Default for GadgetConfiguration<RwLock> {
             protocol: Protocol::Tangle,
             protocol_specific: ProtocolSpecificSettings::Tangle(TangleInstanceSettings {
                 blueprint_id: 0,
-                service_id: 0,
+                service_id: Some(0),
             }),
             bind_port: 0,
             bind_addr: core::net::IpAddr::V4(core::net::Ipv4Addr::new(127, 0, 0, 1)),
@@ -213,6 +213,6 @@ impl<RwLock: lock_api::RawRwLock> GadgetConfiguration<RwLock> {
     pub fn service_id(&self) -> Option<u64> {
         let tangle_settings = self.protocol_specific.tangle().ok()?;
         let TangleInstanceSettings { service_id, .. } = tangle_settings;
-        Some(*service_id)
+        *service_id
     }
 }

--- a/sdk/src/config/mod.rs
+++ b/sdk/src/config/mod.rs
@@ -168,7 +168,12 @@ fn load_inner<RwLock: lock_api::RawRwLock>(
         }),
         Protocol::Tangle => ProtocolSpecificSettings::Tangle(TangleInstanceSettings {
             blueprint_id: blueprint_id.ok_or(Error::MissingBlueprintId)?,
-            service_id: service_id.ok_or(Error::MissingServiceId)?,
+            // If we are in registration mode, we don't need a service id
+            service_id: if !is_registration {
+                Some(service_id.ok_or(Error::MissingServiceId)?)
+            } else {
+                None
+            },
         }),
     };
 

--- a/sdk/src/config/protocol.rs
+++ b/sdk/src/config/protocol.rs
@@ -74,7 +74,9 @@ pub struct TangleInstanceSettings {
     /// The blueprint ID for the Tangle blueprint
     pub blueprint_id: u64,
     /// The service ID for the Tangle blueprint instance
-    pub service_id: u64,
+    ///
+    /// Note: This will be `None` in case this gadget is running in Registration Mode.
+    pub service_id: Option<u64>,
 }
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]

--- a/sdk/src/network/gossip.rs
+++ b/sdk/src/network/gossip.rs
@@ -73,7 +73,7 @@ pub struct NetworkService<'a> {
     pub span: &'a tracing::Span,
 }
 
-impl<'a> NetworkService<'a> {
+impl NetworkService<'_> {
     /// Handle local requests that are meant to be sent to the network.
     pub(crate) fn handle_intra_node_payload(&mut self, msg: IntraNodePayload) {
         let _enter = self.span.enter();

--- a/sdk/src/runners/tangle.rs
+++ b/sdk/src/runners/tangle.rs
@@ -56,13 +56,6 @@ impl BlueprintConfig for TangleConfig {
             }
         };
 
-        // Ensure blueprint_id is set
-        if blueprint_id == 0 {
-            return Err(RunnerError::ConfigError(
-                crate::config::Error::MissingBlueprintId,
-            ));
-        }
-
         // Check if the operator is already registered
         let client = env.client().await?;
         let signer = env.first_sr25519_signer()?;
@@ -100,13 +93,6 @@ impl BlueprintConfig for TangleConfig {
             ));
         };
         let blueprint_id = blueprint_settings.blueprint_id;
-
-        // Ensure blueprint_id is set
-        if blueprint_id == 0 {
-            return Err(RunnerError::ConfigError(
-                crate::config::Error::MissingBlueprintId,
-            ));
-        }
 
         let xt = api::tx().services().register(
             blueprint_id,


### PR DESCRIPTION
This pull request includes several changes to the `sdk` module to improve the handling of `service_id` and streamline the configuration process for Tangle blueprints. The most important changes include making `service_id` optional, adjusting related methods, and removing redundant checks.

Changes to `service_id` handling:

* [`sdk/src/config/gadget_config.rs`](diffhunk://#diff-19106a76235604808c349482ef99f5f7d6a2b4bde9ba373ea1cbcadd8d642f0dL111-R111): Modified `service_id` to be optional in `GadgetConfiguration` and updated the `service_id` method to return the correct type. [[1]](diffhunk://#diff-19106a76235604808c349482ef99f5f7d6a2b4bde9ba373ea1cbcadd8d642f0dL111-R111) [[2]](diffhunk://#diff-19106a76235604808c349482ef99f5f7d6a2b4bde9ba373ea1cbcadd8d642f0dL216-R216)
* [`sdk/src/config/protocol.rs`](diffhunk://#diff-b7ae02d70e04511519adf93b759317bc5d865c66a9f7c7b724f24a47c3cf3143L77-R79): Updated `TangleInstanceSettings` to make `service_id` an `Option<u64>` and added a note for registration mode.

Configuration adjustments:

* [`sdk/src/config/mod.rs`](diffhunk://#diff-22051287d11df0d08075e7ac7232a93d3b6a66fe1cb32962a250940217445e15L171-R176): Adjusted the `load_inner` function to handle `service_id` conditionally based on the registration mode.

Codebase simplification:

* [`sdk/src/runners/tangle.rs`](diffhunk://#diff-1cb61e67105595b4213d02ee3fee2f206381a669f833453fc05e6a75ae043d57L59-L65): Removed redundant checks for `blueprint_id` in `TangleConfig` to allow for zero-based `blueprint_id`s. [[1]](diffhunk://#diff-1cb61e67105595b4213d02ee3fee2f206381a669f833453fc05e6a75ae043d57L59-L65) [[2]](diffhunk://#diff-1cb61e67105595b4213d02ee3fee2f206381a669f833453fc05e6a75ae043d57L104-L110)