### PR TITLE
fix(sdk): Return `Bytes` when using `Vec<u8>` in params and result

### DIFF
--- a/sdk/src/event_listener/tangle/mod.rs
+++ b/sdk/src/event_listener/tangle/mod.rs
@@ -220,13 +220,28 @@ impl_value_to_field_type!(
     AccountId32 => Field::AccountId
 );
 
-impl<T: ValueIntoFieldType> ValueIntoFieldType for Vec<T> {
+impl<T: ValueIntoFieldType + 'static> ValueIntoFieldType for Vec<T> {
     fn into_field_type(self) -> Field<AccountId32> {
-        Field::Array(BoundedVec(
-            self.into_iter()
-                .map(ValueIntoFieldType::into_field_type)
-                .collect(),
-        ))
+        if core::any::TypeId::of::<T>() == core::any::TypeId::of::<u8>() {
+            let (ptr, length, capacity) = {
+                let mut me = core::mem::ManuallyDrop::new(self);
+                (me.as_mut_ptr() as *mut u8, me.len(), me.capacity())
+            };
+            // SAFETY: We are converting a Vec<T> to Vec<u8> only when T is u8.
+            // This is safe because the memory layout of Vec<u8> is the same as Vec<T> when T is u8.
+            // We use ManuallyDrop to prevent double-freeing the memory.
+            // Vec::from_raw_parts takes ownership of the raw parts, ensuring proper deallocation.
+            #[allow(unsafe_code)]
+            Field::Bytes(BoundedVec(unsafe {
+                Vec::from_raw_parts(ptr, length, capacity)
+            }))
+        } else {
+            Field::List(BoundedVec(
+                self.into_iter()
+                    .map(ValueIntoFieldType::into_field_type)
+                    .collect(),
+            ))
+        }
     }
 }
 


### PR DESCRIPTION
This pull request includes an improvement to the `ValueIntoFieldType` implementation in the `sdk/src/event_listener/tangle/mod.rs` file. The main change is the addition of a type check to handle `Vec<u8>` more efficiently and safely.

Enhancements to `ValueIntoFieldType` implementation:

* Added a type check for `Vec<u8>` in the `ValueIntoFieldType` implementation to convert it directly to `Field::Bytes` using `Vec::from_raw_parts`, ensuring proper memory management and avoiding double-freeing issues.


Note that this a hot-fix, to get myself unblocked in my current task. However this won't be needed once #424 is fully implemented.

Closes #427