### PR TITLE
chore: add description to crates

### DIFF
--- a/blueprint-build-utils/Cargo.toml
+++ b/blueprint-build-utils/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [dependencies]
 

--- a/blueprint-build-utils/Cargo.toml
+++ b/blueprint-build-utils/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "blueprint-build-utils"
 version = "0.1.0"
+description = "Tangle Blueprint build utils"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/blueprint-serde/Cargo.toml
+++ b/blueprint-serde/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "gadget-blueprint-serde"
 version = "0.1.0"
+description = "Tangle Blueprints serde integration"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/blueprint-test-utils/Cargo.toml
+++ b/blueprint-test-utils/Cargo.toml
@@ -2,6 +2,7 @@
 name = "blueprint-test-utils"
 version = "0.1.1"
 edition = "2021"
+description = "Tangle Blueprint test utils"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This pull request includes updates to the `Cargo.toml` files of several packages to add descriptions and modify the publish settings. The most important changes include adding descriptions to the packages and setting the `publish` attribute to `false` for certain packages.

Updates to package descriptions:

* [`blueprint-build-utils/Cargo.toml`](diffhunk://#diff-c58966cde75cf027a9ef41416e508ed65536c76b27495f4c7ada5a005a65ae40R4-R10): Added description "Tangle Blueprint build utils".
* [`blueprint-serde/Cargo.toml`](diffhunk://#diff-121573d071b609976749a70d075ea45faace82116bd50b0c6a967e2211ddd30eR4): Added description "Tangle Blueprints serde integration".
* [`blueprint-test-utils/Cargo.toml`](diffhunk://#diff-ef317052248e4c3812ee440fede2706ea12802e7a10b3d4d2fd4a8bfbb280e42R5): Added description "Tangle Blueprint test utils".

Modification to publish settings:

* [`blueprint-build-utils/Cargo.toml`](diffhunk://#diff-c58966cde75cf027a9ef41416e508ed65536c76b27495f4c7ada5a005a65ae40R4-R10): Set `publish` attribute to `false`.
* [`blueprint-test-utils/Cargo.toml`](diffhunk://#diff-ef317052248e4c3812ee440fede2706ea12802e7a10b3d4d2fd4a8bfbb280e42R5): Set `publish` attribute to `false`.