### PR TITLE
chore: improve test-utils and lower networking log level

### DIFF
--- a/blueprint-test-utils/src/lib.rs
+++ b/blueprint-test-utils/src/lib.rs
@@ -471,10 +471,15 @@ pub async fn wait_for_completion_of_tangle_job(
     required_count: usize,
 ) -> Result<JobResultSubmitted, Box<dyn Error>> {
     let mut count = 0;
-    loop {
-        let events = client.events().at_latest().await?;
+    let mut blocks = client.blocks().subscribe_best().await?;
+    while let Some(Ok(block)) = blocks.next().await {
+        let events = block.events().await?;
         let results = events.find::<JobResultSubmitted>().collect::<Vec<_>>();
         info!(
+            %service_id,
+            %call_id,
+            %required_count,
+            %count,
             "Waiting for job completion. Found {} results ...",
             results.len()
         );
@@ -493,9 +498,8 @@ pub async fn wait_for_completion_of_tangle_job(
                 }
             }
         }
-
-        tokio::time::sleep(Duration::from_millis(4000)).await;
     }
+    Err("Failed to get job result".into())
 }
 
 pub async fn get_next_blueprint_id(client: &TestClient) -> Result<u64, Box<dyn Error>> {

--- a/sdk/src/network/gossip.rs
+++ b/sdk/src/network/gossip.rs
@@ -20,7 +20,7 @@ use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 
 use crate::error::Error;
-use crate::{debug, error, trace, warn};
+use crate::{error, trace, warn};
 
 use super::{Network, ParticipantInfo, ProtocolMessage};
 
@@ -157,7 +157,7 @@ impl NetworkService<'_> {
                 address,
                 listener_id,
             } => {
-                debug!("{listener_id} has a new address: {address}");
+                trace!("{listener_id} has a new address: {address}");
             }
             ConnectionEstablished {
                 peer_id,
@@ -226,7 +226,7 @@ impl NetworkService<'_> {
                 peer_id,
                 connection_id,
             } => {
-                debug!("Dialing peer: {peer_id:?} with connection_id: {connection_id}");
+                trace!("Dialing peer: {peer_id:?} with connection_id: {connection_id}");
             }
             NewExternalAddrCandidate { address } => {
                 trace!("New external address candidate: {address}");

--- a/sdk/src/network/handlers/connections.rs
+++ b/sdk/src/network/handlers/connections.rs
@@ -1,7 +1,7 @@
 #![allow(unused_results, clippy::used_underscore_binding)]
 
 use crate::network::gossip::{MyBehaviourRequest, NetworkService};
-use crate::{debug, error};
+use crate::{error, trace};
 use libp2p::PeerId;
 use sp_core::{keccak_256, Pair};
 
@@ -12,7 +12,7 @@ impl NetworkService<'_> {
         peer_id: PeerId,
         num_established: u32,
     ) {
-        debug!("Connection established");
+        trace!("Connection established");
         if num_established == 1 {
             let my_peer_id = self.swarm.local_peer_id();
             let msg = my_peer_id.to_bytes();
@@ -40,7 +40,7 @@ impl NetworkService<'_> {
         num_established: u32,
         _cause: Option<libp2p::swarm::ConnectionError>,
     ) {
-        debug!("Connection closed");
+        trace!("Connection closed");
         if num_established == 0 {
             self.swarm
                 .behaviour_mut()
@@ -56,7 +56,7 @@ impl NetworkService<'_> {
         _local_addr: libp2p::Multiaddr,
         _send_back_addr: libp2p::Multiaddr,
     ) {
-        debug!("Incoming connection");
+        trace!("Incoming connection");
     }
 
     #[tracing::instrument(skip(self))]
@@ -65,7 +65,7 @@ impl NetworkService<'_> {
         peer_id: PeerId,
         _connection_id: libp2p::swarm::ConnectionId,
     ) {
-        debug!("Outgoing connection to peer: {peer_id}");
+        trace!("Outgoing connection to peer: {peer_id}");
     }
 
     #[tracing::instrument(skip(self, error))]

--- a/sdk/src/network/handlers/dcutr.rs
+++ b/sdk/src/network/handlers/dcutr.rs
@@ -1,9 +1,9 @@
-use crate::debug;
 use crate::network::gossip::NetworkService;
+use crate::trace;
 
 impl NetworkService<'_> {
     #[tracing::instrument(skip(self, event))]
     pub async fn handle_dcutr_event(&mut self, event: libp2p::dcutr::Event) {
-        debug!("DCUTR event: {event:?}");
+        trace!("DCUTR event: {event:?}");
     }
 }

--- a/sdk/src/network/handlers/gossip.rs
+++ b/sdk/src/network/handlers/gossip.rs
@@ -2,7 +2,7 @@
 
 use crate::network::gossip::{GossipMessage, NetworkService};
 
-use crate::{debug, error, trace};
+use crate::{error, trace};
 use libp2p::gossipsub::TopicHash;
 use libp2p::{gossipsub, PeerId};
 use std::sync::atomic::AtomicU32;
@@ -78,7 +78,7 @@ impl NetworkService<'_> {
             error!("Got message from unknown peer");
             return;
         };
-        debug!("Got message from peer: {origin}");
+        trace!("Got message from peer: {origin}");
         match bincode::deserialize::<GossipMessage>(&message.data) {
             Ok(GossipMessage { topic, raw_payload }) => {
                 if let Some((_, tx, _)) = self

--- a/sdk/src/network/handlers/identify.rs
+++ b/sdk/src/network/handlers/identify.rs
@@ -1,5 +1,5 @@
 use crate::network::gossip::NetworkService;
-use crate::{debug, error, trace};
+use crate::{error, trace};
 
 impl NetworkService<'_> {
     #[tracing::instrument(skip(self, event))]
@@ -14,7 +14,7 @@ impl NetworkService<'_> {
                     format!("Supported Protocols: {:?}", info.protocols),
                 ];
                 let info_lines = info_lines.join(", ");
-                debug!("Received identify event from peer: {peer_id} with info: {info_lines}");
+                trace!("Received identify event from peer: {peer_id} with info: {info_lines}");
                 self.swarm.add_external_address(info.observed_addr);
             }
             Sent { peer_id, .. } => {
@@ -27,7 +27,7 @@ impl NetworkService<'_> {
                     format!("Supported Protocols: {:?}", info.protocols),
                 ];
                 let info_lines = info_lines.join(", ");
-                debug!("Pushed identify event to peer: {peer_id} with info: {info_lines}");
+                trace!("Pushed identify event to peer: {peer_id} with info: {info_lines}");
             }
             Error { peer_id, error, .. } => {
                 error!("Identify error from peer: {peer_id} with error: {error}");

--- a/sdk/src/network/handlers/mdns.rs
+++ b/sdk/src/network/handlers/mdns.rs
@@ -1,5 +1,5 @@
 use crate::network::gossip::NetworkService;
-use crate::{debug, error};
+use crate::{error, trace};
 use libp2p::mdns;
 
 impl NetworkService<'_> {
@@ -9,7 +9,7 @@ impl NetworkService<'_> {
         match event {
             Discovered(list) => {
                 for (peer_id, multiaddr) in list {
-                    debug!("discovered a new peer: {peer_id} on {multiaddr}");
+                    trace!("discovered a new peer: {peer_id} on {multiaddr}");
                     self.swarm
                         .behaviour_mut()
                         .gossipsub
@@ -21,7 +21,7 @@ impl NetworkService<'_> {
             }
             Expired(list) => {
                 for (peer_id, multiaddr) in list {
-                    debug!("discover peer has expired: {peer_id} with {multiaddr}");
+                    trace!("discover peer has expired: {peer_id} with {multiaddr}");
                     self.swarm
                         .behaviour_mut()
                         .gossipsub

--- a/sdk/src/network/handlers/p2p.rs
+++ b/sdk/src/network/handlers/p2p.rs
@@ -1,7 +1,7 @@
 #![allow(unused_results)]
 
 use crate::network::gossip::{MyBehaviourRequest, MyBehaviourResponse, NetworkService};
-use crate::{debug, error, warn};
+use crate::{debug, error, trace, warn};
 
 use libp2p::gossipsub::IdentTopic;
 use libp2p::{request_response, PeerId};
@@ -17,7 +17,7 @@ impl NetworkService<'_> {
         use request_response::Event::{InboundFailure, Message, OutboundFailure, ResponseSent};
         match event {
             Message { peer, message } => {
-                debug!("Received P2P message from: {peer}");
+                trace!("Received P2P message from: {peer}");
                 self.handle_p2p_message(peer, message).await;
             }
             OutboundFailure {
@@ -53,7 +53,7 @@ impl NetworkService<'_> {
                 channel,
                 request_id,
             } => {
-                debug!("Received request with request_id: {request_id} from peer: {peer}");
+                trace!("Received request with request_id: {request_id} from peer: {peer}");
                 self.handle_p2p_request(peer, request_id, request, channel)
                     .await;
             }
@@ -61,7 +61,7 @@ impl NetworkService<'_> {
                 response,
                 request_id,
             } => {
-                debug!("Received response from peer: {peer} with request_id: {request_id}");
+                trace!("Received response from peer: {peer} with request_id: {request_id}");
                 self.handle_p2p_response(peer, request_id, response).await;
             }
         }
@@ -116,7 +116,7 @@ impl NetworkService<'_> {
                 ecdsa_public_key,
                 signature,
             } => {
-                debug!("Received handshake from peer: {peer}");
+                trace!("Received handshake from peer: {peer}");
                 // Verify the signature
                 let msg = peer.to_bytes();
                 let hash = keccak_256(&msg);

--- a/sdk/src/network/handlers/ping.rs
+++ b/sdk/src/network/handlers/ping.rs
@@ -1,9 +1,9 @@
-use crate::debug;
 use crate::network::gossip::NetworkService;
+use crate::trace;
 
 impl NetworkService<'_> {
     #[tracing::instrument(skip(self, event))]
     pub async fn handle_ping_event(&mut self, event: libp2p::ping::Event) {
-        debug!("Ping event: {event:?}")
+        trace!("Ping event: {event:?}")
     }
 }

--- a/sdk/src/network/handlers/relay.rs
+++ b/sdk/src/network/handlers/relay.rs
@@ -1,14 +1,14 @@
-use crate::debug;
 use crate::network::gossip::NetworkService;
+use crate::trace;
 
 impl NetworkService<'_> {
     #[tracing::instrument(skip(self, event))]
     pub async fn handle_relay_event(&mut self, event: libp2p::relay::Event) {
-        debug!("Relay event: {event:?}");
+        trace!("Relay event: {event:?}");
     }
 
     #[tracing::instrument(skip(self, event))]
     pub async fn handle_relay_client_event(&mut self, event: libp2p::relay::client::Event) {
-        debug!("Relay client event: {event:?}");
+        trace!("Relay client event: {event:?}");
     }
 }


### PR DESCRIPTION
This pull request includes several changes aimed at improving the logging granularity and updating the job completion mechanism in the `blueprint-test-utils` and `sdk` modules.

### Improvements to logging granularity:

* [`sdk/src/network/gossip.rs`](diffhunk://#diff-eaa31da1831a49959d61586dde5384769520acbbe1476224c7abb52e4884e930L160-R160): Replaced `debug` logging with `trace` logging for various network events to provide more detailed logs. [[1]](diffhunk://#diff-eaa31da1831a49959d61586dde5384769520acbbe1476224c7abb52e4884e930L160-R160) [[2]](diffhunk://#diff-eaa31da1831a49959d61586dde5384769520acbbe1476224c7abb52e4884e930L229-R229)
* [`sdk/src/network/handlers/connections.rs`](diffhunk://#diff-2ecadd63691535c8527fb5b7ce03ba46e015323f2945b083b59c73bb21819d28L15-R15): Updated several log statements from `debug` to `trace` to enhance log detail for connection events. [[1]](diffhunk://#diff-2ecadd63691535c8527fb5b7ce03ba46e015323f2945b083b59c73bb21819d28L15-R15) [[2]](diffhunk://#diff-2ecadd63691535c8527fb5b7ce03ba46e015323f2945b083b59c73bb21819d28L43-R43) [[3]](diffhunk://#diff-2ecadd63691535c8527fb5b7ce03ba46e015323f2945b083b59c73bb21819d28L59-R59) [[4]](diffhunk://#diff-2ecadd63691535c8527fb5b7ce03ba46e015323f2945b083b59c73bb21819d28L68-R68)
* `sdk/src/network/handlers/dcutr.rs`, `sdk/src/network/handlers/gossip.rs`, `sdk/src/network/handlers/identify.rs`, `sdk/src/network/handlers/mdns.rs`, `sdk/src/network/handlers/p2p.rs`, `sdk/src/network/handlers/ping.rs`, `sdk/src/network/handlers/relay.rs`: Consistently replaced `debug` logging with `trace` logging across multiple handler files to improve log granularity. [[1]](diffhunk://#diff-34aa5ac59c41f0d79ecc9f7c1be56335388d897dbd3804d4e4e24bee4291da29L1-R7) [[2]](diffhunk://#diff-7257d41590a79cf8df1353111dbdd7612aa726471e37e80ad09c8921da05ab8dL81-R81) [[3]](diffhunk://#diff-a70539fc5eddbb8307074fdc3d41e9c1aabf578c11d5eb342a0b2a5f4a3e2113L17-R17) [[4]](diffhunk://#diff-0ed46d774dc863b47883867204da265ab8fddcc559eda96261c175979b6f80b6L12-R12) [[5]](diffhunk://#diff-118cb28d332ba4d6efe049f75450d0680aa50b427afaea8ed45fa68d9e388bc1L20-R20) [[6]](diffhunk://#diff-6f31ad8dfa4cb4e8666a7b9f82c3fd8876d3b9c9bcd21c17f6ca3a4b404ba434L1-R7) [[7]](diffhunk://#diff-bd231307a58a872df7420f478af6e97e930b655930e30d1c22340c4b2d36fc74L1-R12)

### Job completion mechanism update:

* [`blueprint-test-utils/src/lib.rs`](diffhunk://#diff-c499bdcd78ea59396d854b3024b664efda437404e4fdb64c79a74910e400465aL474-R482): Changed the job completion waiting mechanism to use a subscription to the best blocks instead of polling for events, improving efficiency and reliability. [[1]](diffhunk://#diff-c499bdcd78ea59396d854b3024b664efda437404e4fdb64c79a74910e400465aL474-R482) [[2]](diffhunk://#diff-c499bdcd78ea59396d854b3024b664efda437404e4fdb64c79a74910e400465aL496-R502)