### PR TITLE
chore: set blueprint-manager publishable

### DIFF
--- a/blueprint-manager/Cargo.toml
+++ b/blueprint-manager/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "blueprint-manager"
 version = "0.1.1"
-edition = "2021"
-publish = false
+description = "Tangle Blueprint manager and Runner"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "blueprint-manager"

--- a/blueprint-manager/Cargo.toml
+++ b/blueprint-manager/Cargo.toml
@@ -38,3 +38,6 @@ failure = { workspace = true }
 [features]
 default = ["std"]
 std = ["gadget-io/std", "gadget-sdk/std", "tangle-subxt/std"]
+
+[package.metadata.dist]
+dist = false

--- a/blueprint-test-utils/Cargo.toml
+++ b/blueprint-test-utils/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "blueprint-test-utils"
 version = "0.1.1"
-edition = "2021"
 description = "Tangle Blueprint test utils"
-publish = true
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This pull request includes changes to the `Cargo.toml` files for the `blueprint-manager` and `blueprint-test-utils` packages to utilize workspace settings for various metadata fields.

Changes to `blueprint-manager`:

* [`blueprint-manager/Cargo.toml`](diffhunk://#diff-dd70089194a21e881d628a3f5773cb2737b6b313d83c831df04ac88d836f71f8L4-R9): Added workspace settings for `authors`, `edition`, `homepage`, `repository`, and `license`, and updated the `description` field.

Changes to `blueprint-test-utils`:

* [`blueprint-test-utils/Cargo.toml`](diffhunk://#diff-ef317052248e4c3812ee440fede2706ea12802e7a10b3d4d2fd4a8bfbb280e42L4-R9): Added workspace settings for `authors`, `edition`, `homepage`, `repository`, and `license`.