### PR TITLE
feat(gadget-sdk)!: add more Docker utils

### DIFF
--- a/sdk/src/docker.rs
+++ b/sdk/src/docker.rs
@@ -187,6 +187,7 @@ impl<'a> Container<'a> {
         let config = Config {
             image: Some(self.image.clone()),
             cmd: self.options.cmd.clone(),
+            env: self.options.env.clone(),
             attach_stdout: Some(true),
             host_config: Some(HostConfig {
                 binds: self.options.binds.clone(),

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -30,7 +30,7 @@ pub enum Error {
     Executor(#[from] crate::executor::process::Error),
 
     #[error("Docker error: {0}")]
-    Docker(#[from] bollard::errors::Error),
+    Docker(#[from] crate::docker::Error),
 
     #[error("Missing network ID")]
     MissingNetworkId,

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -68,6 +68,12 @@ pub enum Error {
     Other(String),
 }
 
+impl From<bollard::errors::Error> for Error {
+    fn from(error: bollard::errors::Error) -> Self {
+        Error::Docker(crate::docker::Error::from(error))
+    }
+}
+
 impl From<String> for Error {
     fn from(s: String) -> Self {
         Error::Other(s)

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -9,7 +9,6 @@
 #![cfg_attr(all(not(feature = "std"), not(feature = "wasm")), no_std)]
 
 extern crate alloc;
-extern crate core;
 
 /// Benchmark Module
 #[cfg(any(feature = "std", feature = "wasm"))]


### PR DESCRIPTION
## Added
* `Container::from_id` - Lookup an existing container based on its ID
* `Container::status` - Get the status of a container (created, running, dead, etc)

## Fixed
* Env vars not actually being passed to containers

## Breaking
* Changed the type of `gadget_sdk::Error::Docker`