### PR TITLE
fix(gadget-blueprint-serde)!: handle bytes properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4756,6 +4756,7 @@ version = "0.2.0"
 dependencies = [
  "paste",
  "serde",
+ "serde_bytes",
  "serde_test",
  "tangle-subxt",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ reqwest = "0.12.7"
 rustdoc-types = "0.31.0"
 schnorrkel = { version = "0.11.4", default-features = false, features = ["preaudit_deprecated", "getrandom"] }
 serde = { version = "1.0.208", default-features = false }
+serde_bytes = { version = "0.11.15", default-features = false }
 serde_json = "1.0"
 serde_test = "1.0.177"
 sha2 = "0.10.8"

--- a/blueprint-serde/Cargo.toml
+++ b/blueprint-serde/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 [dependencies]
 paste.workspace = true
 serde.workspace = true
+serde_bytes = { workspace = true, features = ["alloc"] }
 tangle-subxt.workspace = true
 
 [dev-dependencies]
@@ -21,4 +22,7 @@ workspace = true
 
 [features]
 default = ["std"]
-std = []
+std = [
+    "serde/std",
+    "serde_bytes/std"
+]

--- a/blueprint-serde/src/lib.rs
+++ b/blueprint-serde/src/lib.rs
@@ -58,6 +58,7 @@ use tangle_subxt::subxt_core::utils::AccountId32;
 pub use tangle_subxt::tangle_testnet_runtime::api::runtime_types::tangle_primitives::services::field::Field;
 pub use tangle_subxt::tangle_testnet_runtime::api::runtime_types::bounded_collections::bounded_vec::BoundedVec;
 pub use ser::new_bounded_string;
+pub use serde_bytes::ByteBuf;
 use error::Result;
 
 /// Derive a [`Field`] from an instance of type `S`

--- a/blueprint-serde/src/ser.rs
+++ b/blueprint-serde/src/ser.rs
@@ -21,10 +21,10 @@ impl<'a> serde::Serializer for &'a mut Serializer {
     type SerializeSeq = SerializeSeq<'a>;
     type SerializeTuple = Self::SerializeSeq;
     type SerializeTupleStruct = SerializeTupleStruct<'a>;
-    type SerializeTupleVariant = Self;
-    type SerializeMap = Self;
+    type SerializeTupleVariant = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeMap = ser::Impossible<Self::Ok, Self::Error>;
     type SerializeStruct = SerializeStruct<'a>;
-    type SerializeStructVariant = Self;
+    type SerializeStructVariant = ser::Impossible<Self::Ok, Self::Error>;
 
     fn serialize_bool(self, v: bool) -> Result<Self::Ok> {
         Ok(Field::Bool(v))
@@ -164,7 +164,7 @@ impl<'a> serde::Serializer for &'a mut Serializer {
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant> {
-        Ok(self)
+        Err(Self::Error::UnsupportedType(UnsupportedType::NonUnitEnum))
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
@@ -187,7 +187,7 @@ impl<'a> serde::Serializer for &'a mut Serializer {
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant> {
-        Ok(self)
+        Err(Self::Error::UnsupportedType(UnsupportedType::NonUnitEnum))
     }
 
     fn is_human_readable(&self) -> bool {
@@ -339,63 +339,6 @@ impl ser::SerializeStruct for SerializeStruct<'_> {
             new_bounded_string(self.name),
             Box::new(BoundedVec(self.fields)),
         ))
-    }
-}
-
-// === UNSUPPORTED TYPES ===
-
-impl ser::SerializeTupleVariant for &mut Serializer {
-    type Ok = Field<AccountId32>;
-    type Error = crate::error::Error;
-
-    fn serialize_field<T>(&mut self, _value: &T) -> Result<()>
-    where
-        T: ?Sized + Serialize,
-    {
-        Err(Self::Error::UnsupportedType(UnsupportedType::NonUnitEnum))
-    }
-
-    fn end(self) -> Result<Self::Ok> {
-        Err(Self::Error::UnsupportedType(UnsupportedType::NonUnitEnum))
-    }
-}
-
-impl ser::SerializeMap for &mut Serializer {
-    type Ok = Field<AccountId32>;
-    type Error = crate::error::Error;
-
-    fn serialize_key<T>(&mut self, _key: &T) -> Result<()>
-    where
-        T: ?Sized + Serialize,
-    {
-        Err(Self::Error::UnsupportedType(UnsupportedType::Map))
-    }
-
-    fn serialize_value<T>(&mut self, _value: &T) -> Result<()>
-    where
-        T: ?Sized + Serialize,
-    {
-        Err(Self::Error::UnsupportedType(UnsupportedType::Map))
-    }
-
-    fn end(self) -> Result<Self::Ok> {
-        Err(Self::Error::UnsupportedType(UnsupportedType::Map))
-    }
-}
-
-impl ser::SerializeStructVariant for &mut Serializer {
-    type Ok = Field<AccountId32>;
-    type Error = crate::error::Error;
-
-    fn serialize_field<T>(&mut self, _key: &'static str, _value: &T) -> Result<()>
-    where
-        T: ?Sized + Serialize,
-    {
-        Err(Self::Error::UnsupportedType(UnsupportedType::NonUnitEnum))
-    }
-
-    fn end(self) -> Result<Self::Ok> {
-        Err(Self::Error::UnsupportedType(UnsupportedType::NonUnitEnum))
     }
 }
 

--- a/macros/blueprint-proc-macro/src/shared.rs
+++ b/macros/blueprint-proc-macro/src/shared.rs
@@ -88,6 +88,10 @@ pub fn path_to_field_type(path: &syn::Path) -> syn::Result<FieldType> {
         .last()
         .ok_or_else(|| syn::Error::new_spanned(path, "path must have at least one segment"))?;
     let ident = &seg.ident;
+    if ident == "ByteBuf" {
+        return Ok(FieldType::Bytes);
+    }
+    
     let args = &seg.arguments;
     match args {
         syn::PathArguments::None => {
@@ -104,10 +108,7 @@ pub fn path_to_field_type(path: &syn::Path) -> syn::Result<FieldType> {
             let inner_arg = &inner.args[0];
             if let syn::GenericArgument::Type(inner_ty) = inner_arg {
                 let inner_type = type_to_field_type(inner_ty)?;
-                match inner_type.ty {
-                    FieldType::Uint8 => Ok(FieldType::Bytes),
-                    others => Ok(FieldType::List(Box::new(others))),
-                }
+                Ok(FieldType::List(Box::new(inner_type.ty)))
             } else {
                 Err(syn::Error::new_spanned(
                     inner_arg,

--- a/macros/blueprint-proc-macro/src/shared.rs
+++ b/macros/blueprint-proc-macro/src/shared.rs
@@ -91,7 +91,7 @@ pub fn path_to_field_type(path: &syn::Path) -> syn::Result<FieldType> {
     if ident == "ByteBuf" {
         return Ok(FieldType::Bytes);
     }
-    
+
     let args = &seg.arguments;
     match args {
         syn::PathArguments::None => {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -71,6 +71,7 @@ pub mod utils;
 // Re-exports
 pub use alloy_rpc_types;
 pub use async_trait;
+pub use blueprint_serde::ByteBuf;
 pub use clap;
 pub use error::Error;
 pub use futures;


### PR DESCRIPTION
With `Field::List` and `Field::Bytes` being distinct types, we'll have to rely on `serde_bytes::ByteBuf` to call the `serialize_byte_buf` method. That means any job returning `Vec<u8>` should now return `ByteBuf`, which has been re-exported in the SDK.

Simply:

```rust
fn my_job() -> Result<Vec<u8>> {
	Ok(some_vec)
}
```

To:

```rust
use gadget_sdk::ByteBuf;

fn my_job() -> Result<ByteBuf> {
	Ok(some_vec.into())
}
```