### PR TITLE
chore!: update `tangle-subxt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12287,9 +12287,9 @@ dependencies = [
 
 [[package]]
 name = "tangle-subxt"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66ffe3bf80b02cebae9b5d8b0932becf5638179e4cf7b9c12d0c753b51c5e64"
+checksum = "0cad370e154d2297ed658b566b3ed5320362dfebdcc0f1f38f5194d85bf85f02"
 dependencies = [
  "parity-scale-codec",
  "scale-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ cargo-tangle = { path = "./cli", version = "0.3.1" }
 cargo_metadata = { version = "0.18.1" }
 
 # Tangle-related dependencies
-tangle-subxt = { version = "0.6.0", default-features = false }
+tangle-subxt = { version = "0.7.0", default-features = false }
 subxt-signer = { version = "0.37.0", default-features = false }
 subxt = { version = "0.37.0", default-features = false }
 subxt-core = { version = "0.37.0", default-features = false }


### PR DESCRIPTION
Makes it possible to publish `blueprint-serde`, and then `gadget-sdk`.

closes #511