### PR TITLE
fix(blueprint-proc-macro): fix bug where job IDs are not written in order to blueprint.json

### DIFF
--- a/blueprint-metadata/src/lib.rs
+++ b/blueprint-metadata/src/lib.rs
@@ -152,6 +152,10 @@ fn extract_jobs_from_module<'a>(
             _ => continue,
         }
     }
+
+    // Sort jobs by job_id field
+    jobs.sort_by(|a, b| a.job_id.cmp(&b.job_id));
+
     jobs
 }
 

--- a/macros/blueprint-proc-macro-core/src/lib.rs
+++ b/macros/blueprint-proc-macro-core/src/lib.rs
@@ -142,6 +142,7 @@ pub struct ServiceMetadata<'a> {
 /// It contains the input and output fields of the job with the permitted caller.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct JobDefinition<'a> {
+    pub job_id: u64,
     /// The metadata of the job.
     pub metadata: JobMetadata<'a>,
     /// These are parameters that are required for this job.

--- a/macros/blueprint-proc-macro/src/job.rs
+++ b/macros/blueprint-proc-macro/src/job.rs
@@ -151,7 +151,15 @@ pub fn generate_job_const_block(
 ) -> syn::Result<proc_macro2::TokenStream> {
     let (fn_name_string, job_def_name, job_id_name) = get_job_id_field_name(input);
     // Creates Job Definition using input parameters
+    // convert litint to u64
+    let job_id_as_u64 = u64::from_str(&job_id.to_string()).map_err(|err| {
+        syn::Error::new_spanned(
+            job_id,
+            format!("Failed to convert job id to u64: {err}"),
+        )
+    })?;
     let job_def = JobDefinition {
+        job_id: job_id_as_u64,
         metadata: JobMetadata {
             name: fn_name_string.clone().into(),
             // filled later on during the rustdoc gen.

--- a/macros/blueprint-proc-macro/src/job.rs
+++ b/macros/blueprint-proc-macro/src/job.rs
@@ -151,12 +151,8 @@ pub fn generate_job_const_block(
 ) -> syn::Result<proc_macro2::TokenStream> {
     let (fn_name_string, job_def_name, job_id_name) = get_job_id_field_name(input);
     // Creates Job Definition using input parameters
-    // convert litint to u64
     let job_id_as_u64 = u64::from_str(&job_id.to_string()).map_err(|err| {
-        syn::Error::new_spanned(
-            job_id,
-            format!("Failed to convert job id to u64: {err}"),
-        )
+        syn::Error::new_spanned(job_id, format!("Failed to convert job id to u64: {err}"))
     })?;
     let job_def = JobDefinition {
         job_id: job_id_as_u64,


### PR DESCRIPTION
This PR is for debugging and fixing bugs as I see them.

For example, I got this error when submitting a keygen (job_id=0):

`Failed to submit job: Runtime(Module(ModuleError(<Services::TypeCheck>)))`

When I checked the generated blueprint.json, the keygen job was the second element. So, when I set the job IDs to be in order with the blueprint.json file, that error went away. The real fix is to ensure the listed jobs are sorted by ID.