### PR TITLE
chore(stores): remove `Default` bound on `LocalDatabase`

### DIFF
--- a/crates/stores/local-database/src/lib.rs
+++ b/crates/stores/local-database/src/lib.rs
@@ -26,7 +26,7 @@ pub struct LocalDatabase<T> {
 
 impl<T> LocalDatabase<T>
 where
-    T: Serialize + DeserializeOwned + Clone + Default,
+    T: Serialize + DeserializeOwned + Clone,
 {
     /// Reads a `LocalDatabase` from the given path.
     ///


### PR DESCRIPTION
It's an unnecessary bound, just adds friction