### PR TITLE
feat(blueprint-metadata): nicer errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2626,6 +2626,7 @@ dependencies = [
  "rustdoc-types",
  "serde",
  "serde_json",
+ "thiserror 2.0.11",
  "typed-builder",
 ]
 

--- a/crates/blueprint/metadata/Cargo.toml
+++ b/crates/blueprint/metadata/Cargo.toml
@@ -18,3 +18,4 @@ serde_json.workspace = true
 rustdoc-types.workspace = true
 cargo_metadata.workspace = true
 fs2.workspace = true
+thiserror.workspace = true


### PR DESCRIPTION
This only adds error messages for some cases. Many others are still just panics.

This also fixes the issue of missing metadata producing an empty `BlueprintMetadata` and allowing the crate to continue building. It's now a hard error.

Removing the metadata from `incredible-squaring` yields:

```
warning: incredible-squaring-blueprint@0.1.1: Failed to generate blueprint metadata: Blueprint metadata not found in the Cargo.toml
error: failed to run custom build command for `incredible-squaring-blueprint v0.1.1 (<path>/blueprints/incredible-squaring)`

Caused by:
  process didn't exit successfully: `<path>/target/debug/build/incredible-squaring-blueprint-a1eaf06037a611fc/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-changed=src/lib.rs
  cargo:rerun-if-changed=src/main.rs
  Adding test fetcher since none exists
  cargo:warning=Failed to generate blueprint metadata: Blueprint metadata not found in the Cargo.toml

  --- stderr
  Reading JSON from <path>/blueprints/incredible-squaring/target/blueprint/doc/incredible_squaring_blueprint.json
  [INFO] Extracted 1 job definitions
  [WARN] No gadget metadata found in the Cargo.toml.
  [WARN] For more information, see: <TODO>
  [ERROR]: No blueprint metadata found in the Cargo.toml.
  [ERROR]: For more information, see: <TODO>
```

Notice the new cargo warning message up top and the log levels in stderr. Still isn't that pretty, but it's the best that can be done AFAIK.