### PR TITLE
feat(blueprint-metadata): support custom types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,7 @@ jobs:
             gadget-event-listeners-core,
             gadget-event-listeners-cronjob,
 
+            blueprint-metadata,
             gadget-blueprint-serde,
             gadget-config,
             gadget-keystore,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2626,6 +2626,7 @@ dependencies = [
  "rustdoc-types",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.11",
  "typed-builder",
 ]

--- a/blueprints/incredible-squaring/build.rs
+++ b/blueprints/incredible-squaring/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    println!("cargo:rerun-if-changed=src/lib.rs");
-    println!("cargo:rerun-if-changed=src/main.rs");
+    println!("cargo::rerun-if-changed=src/lib.rs");
+    println!("cargo::rerun-if-changed=src/main.rs");
     blueprint_metadata::generate_json();
 }

--- a/crates/blueprint/metadata/Cargo.toml
+++ b/crates/blueprint/metadata/Cargo.toml
@@ -19,3 +19,6 @@ rustdoc-types.workspace = true
 cargo_metadata.workspace = true
 fs2.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/blueprint/metadata/src/lib.rs
+++ b/crates/blueprint/metadata/src/lib.rs
@@ -10,7 +10,10 @@ use gadget_blueprint_proc_macro_core::{
     TestFetcher,
 };
 
-use rustdoc_types::{Crate, Id, Item, ItemEnum, Module};
+use rustdoc_types::{
+    Crate, Enum, Function, Id, Item, ItemEnum, ItemKind, Module, Struct, StructKind, Type,
+    VariantKind,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -20,6 +23,19 @@ pub enum Error {
     DeserializeGadget(serde_json::Error),
     #[error("Unsupported blueprint manager")]
     UnsupportedBlueprintManager,
+
+    #[error("Unit structs are not supported (job: {job}, type: {ty})")]
+    UnitStruct { job: String, ty: String },
+    #[error("Non-unit enums are not supported (job: {job}, type: {ty})")]
+    NonUnitEnum { job: String, ty: String },
+    #[error("Unsupported type: {0:?}")]
+    UnsupportedType(ItemKind),
+
+    #[error("Failed to generate rustdoc (status: {status:?}, command: {command})")]
+    RustdocFailed {
+        status: Option<i32>,
+        command: String,
+    },
 }
 
 /// Generate `blueprint.json` to the current crate working directory next to `build.rs` file.
@@ -35,6 +51,23 @@ pub struct Config {
     /// The output path of the generated `blueprint.json` file.
     #[builder(default, setter(strip_option))]
     output_file: Option<PathBuf>,
+    /// The name of the crate to generate the blueprint for, defaults to `CARGO_PKG_NAME`.
+    #[builder(default, setter(strip_option))]
+    crate_name: Option<String>,
+    /// The target directory where `rustdoc` output is stored. Defaults to "[`manifest_dir`](Self::manifest_dir)/target".
+    #[builder(default, setter(strip_option))]
+    target_dir: Option<PathBuf>,
+    /// The  directory where `Cargo.toml` resides. Defaults to `CARGO_MANIFEST_DIR`.
+    #[builder(default, setter(strip_option))]
+    manifest_dir: Option<PathBuf>,
+}
+
+#[derive(Default)]
+struct Context {
+    current_job: String,
+    crates: HashMap<u32, Crate>,
+    target_dir: PathBuf,
+    manifest_dir: PathBuf,
 }
 
 impl Config {
@@ -44,22 +77,39 @@ impl Config {
                 .expect("Failed to get current directory")
                 .join("blueprint.json")
         });
-        let krate = generate_rustdoc()?;
+
+        let crate_name = self.crate_name.unwrap_or_else(|| {
+            std::env::var("CARGO_PKG_NAME").expect("Failed to get package name")
+        });
+        let manifest_dir = self.manifest_dir.unwrap_or_else(|| {
+            std::env::var("CARGO_MANIFEST_DIR")
+                .expect("Failed to get manifest directory")
+                .into()
+        });
+        let target_dir = self
+            .target_dir
+            .unwrap_or_else(|| manifest_dir.join("target"));
+
+        let krate = generate_rustdoc(&crate_name, &manifest_dir, &target_dir)?;
+
         // Extract the job definitions from the rustdoc output
-        let jobs = extract_jobs(&krate)?;
+        let mut context = Context {
+            target_dir,
+            manifest_dir,
+            ..Default::default()
+        };
+
+        let jobs = extract_jobs(&mut context, &krate)?;
         eprintln!("[INFO] Extracted {} job definitions", jobs.len());
         let hooks = extract_hooks(&krate)?;
-        let metadata = extract_metadata()?;
-        let crate_name = std::env::var("CARGO_PKG_NAME").expect("Failed to get package name");
+        let metadata = extract_metadata(&context.manifest_dir)?;
         let package = find_package(&metadata, &crate_name);
-        let gadget = generate_gadget(package)?;
+        let gadget = generate_gadget(package, &context.manifest_dir)?;
         let metadata = extract_blueprint_metadata(package)?;
         eprintln!("Generating blueprint.json to {:?}", output_file);
         let blueprint = ServiceBlueprint {
             metadata: ServiceMetadata {
-                name: std::env::var("CARGO_PKG_NAME")
-                    .expect("Failed to get package name")
-                    .into(),
+                name: crate_name.into(),
                 description: std::env::var("CARGO_PKG_DESCRIPTION").map(Into::into).ok(),
                 author: std::env::var("CARGO_PKG_AUTHORS").map(Into::into).ok(),
                 category: std::env::var("CARGO_PKG_KEYWORDS").map(Into::into).ok(),
@@ -113,7 +163,10 @@ fn extract_hooks(krate: &Crate) -> Result<Vec<Hook>, Error> {
 }
 
 /// Extract job definitions from the rustdoc output.
-fn extract_jobs(krate: &Crate) -> Result<Vec<JobDefinition<'_>>, Error> {
+fn extract_jobs<'a>(
+    context: &mut Context,
+    krate: &'a Crate,
+) -> Result<Vec<JobDefinition<'a>>, Error> {
     let root_module = krate
         .index
         .get(&krate.root)
@@ -121,23 +174,23 @@ fn extract_jobs(krate: &Crate) -> Result<Vec<JobDefinition<'_>>, Error> {
     let ItemEnum::Module(blueprint_crate) = &root_module.inner else {
         panic!("Failed to get blueprint crate module");
     };
-    extract_jobs_from_module(&krate.root, &krate.index, blueprint_crate)
+    extract_jobs_from_module(context, krate, blueprint_crate)
 }
 
 /// Extracts job definitions from a module.
 fn extract_jobs_from_module<'a>(
-    _root: &'a Id,
-    index: &'a HashMap<Id, Item>,
+    context: &mut Context,
+    krate: &'a Crate,
     module: &'a Module,
 ) -> Result<Vec<JobDefinition<'a>>, Error> {
     let mut jobs = vec![];
     let automatically_derived: String = String::from("#[automatically_derived]");
     const JOB_DEF: &str = "JOB_DEF";
     for item_id in &module.items {
-        let item = index.get(item_id).expect("Failed to get item");
+        let item = krate.index.get(item_id).expect("Failed to get item");
         match &item.inner {
             ItemEnum::Module(m) => {
-                jobs.extend(extract_jobs_from_module(_root, index, m)?);
+                jobs.extend(extract_jobs_from_module(context, krate, m)?);
             }
             // Handle only the constant items that are automatically derived and have the JOB_DEF in their name
             ItemEnum::Constant { const_: c, .. }
@@ -149,16 +202,45 @@ fn extract_jobs_from_module<'a>(
                         .unwrap_or(false) =>
             {
                 let linked_function_id = item.links.values().next().expect("No linked functions");
-                let linked_function = index
+                let linked_function = krate
+                    .index
                     .get(linked_function_id)
                     .expect("Failed to get linked function");
-                assert!(
-                    matches!(linked_function.inner, ItemEnum::Function(_)),
-                    "Linked item is not a function"
-                );
+                let ItemEnum::Function(function) = &linked_function.inner else {
+                    panic!("Linked item is not a function");
+                };
+
+                let mut contains_non_primitive_types = false;
+                if !function.sig.inputs.is_empty() {
+                    // Skip the last parameter, which is the context
+                    for (_, param_ty) in function
+                        .sig
+                        .inputs
+                        .iter()
+                        .take(function.sig.inputs.len() - 1)
+                    {
+                        if let Type::Primitive(_) = param_ty {
+                            continue;
+                        }
+
+                        contains_non_primitive_types = true;
+                    }
+                }
+
+                if !contains_non_primitive_types {
+                    contains_non_primitive_types =
+                        matches!(&function.sig.output, Some(Type::Primitive(_)) | None);
+                }
+
                 let mut job_def: JobDefinition =
                     serde_json::from_str(&unescape_json_string(&c.expr))
                         .expect("Failed to deserialize job definition");
+
+                context.current_job = job_def.metadata.name.to_string();
+                if contains_non_primitive_types {
+                    extract_non_primitive_parameters(context, &mut job_def, krate, function)?;
+                }
+
                 job_def.metadata.description = linked_function.docs.as_ref().map(Into::into);
                 jobs.push(job_def);
             }
@@ -170,6 +252,177 @@ fn extract_jobs_from_module<'a>(
     jobs.sort_by(|a, b| a.job_id.cmp(&b.job_id));
 
     Ok(jobs)
+}
+
+fn extract_non_primitive_parameters(
+    context: &mut Context,
+    job_def: &mut JobDefinition,
+    krate: &Crate,
+    function: &Function,
+) -> Result<(), Error> {
+    // The function signature will also include the context, so we need to subtract 1
+    assert_eq!(job_def.params.len(), function.sig.inputs.len() - 1);
+
+    for (index, (_name, ty)) in function
+        .sig
+        .inputs
+        .iter()
+        .enumerate()
+        .take(job_def.params.len())
+    {
+        job_def.params[index] = walk_type(context, ty, krate)?;
+    }
+
+    Ok(())
+}
+
+fn walk_type(context: &mut Context, ty: &Type, krate: &Crate) -> Result<FieldType, Error> {
+    fn on_primitive(name: &str) -> Result<FieldType, Error> {
+        match name {
+            "bool" => Ok(FieldType::Bool),
+            "u8" => Ok(FieldType::Uint8),
+            "u16" => Ok(FieldType::Uint16),
+            "u32" => Ok(FieldType::Uint32),
+            "u64" => Ok(FieldType::Uint64),
+            "u128" => Ok(FieldType::Uint128),
+            "i8" => Ok(FieldType::Int8),
+            "i16" => Ok(FieldType::Int16),
+            "i32" => Ok(FieldType::Int32),
+            "i64" => Ok(FieldType::Int64),
+            "i128" => Ok(FieldType::Int128),
+            "f32" | "f64" => Ok(FieldType::Float64),
+            "char" => todo!("char"),
+            _ => panic!("Unexpected primitive type"),
+        }
+    }
+
+    match ty {
+        Type::ResolvedPath(path) => {
+            let Some(qualified_path) = krate.paths.get(&path.id) else {
+                panic!("Failed to get qualified path");
+            };
+
+            match qualified_path.kind {
+                ItemKind::Struct | ItemKind::Enum | ItemKind::Primitive => {}
+                kind => return Err(Error::UnsupportedType(kind)),
+            }
+
+            let krate_to_check = if qualified_path.crate_id == 0 {
+                krate
+            } else {
+                let external_krate = krate
+                    .external_crates
+                    .get(&qualified_path.crate_id)
+                    .expect("Failed to get crate");
+                context
+                    .crates
+                    .entry(qualified_path.crate_id)
+                    .or_insert_with(|| {
+                        generate_rustdoc(
+                            &external_krate.name,
+                            &context.manifest_dir,
+                            &context.target_dir,
+                        )
+                        .unwrap()
+                    });
+
+                todo!("lookup crate");
+            };
+
+            let item = krate_to_check
+                .index
+                .get(&path.id)
+                .expect("Failed to get struct");
+
+            match &item.inner {
+                ItemEnum::Struct(s) => {
+                    walk_struct(context, item.name.as_ref().unwrap(), s, krate_to_check)
+                }
+                ItemEnum::Enum(e) => {
+                    verify_enum(context, item.name.as_ref().unwrap(), e, krate_to_check)?;
+                    Ok(FieldType::String)
+                }
+                ItemEnum::Primitive(p) => on_primitive(&p.name),
+                _ => unreachable!("Should only have supported types at this point"),
+            }
+        }
+
+        Type::Primitive(primitive) => on_primitive(primitive),
+        Type::Tuple(_) => todo!("tuple types"),
+        Type::Array { .. } => todo!("array types"),
+        Type::QualifiedPath { .. } => todo!("qualified path types"),
+        _ => panic!("Unexpected type"),
+    }
+}
+
+fn walk_struct(
+    context: &mut Context,
+    name: &str,
+    s: &Struct,
+    krate: &Crate,
+) -> Result<FieldType, Error> {
+    match &s.kind {
+        StructKind::Unit => Err(Error::UnitStruct {
+            job: context.current_job.clone(),
+            ty: name.to_string(),
+        }),
+        StructKind::Tuple(fields) => {
+            let mut resolved_fields = Vec::with_capacity(fields.len());
+            for field in fields {
+                let field = field.unwrap();
+                let struct_field_item = krate.index.get(&field).expect("Failed to get field");
+                let ItemEnum::StructField(struct_field_ty) = &struct_field_item.inner else {
+                    panic!("Expected struct field")
+                };
+
+                resolved_fields.push((
+                    struct_field_item.name.clone().unwrap(),
+                    Box::new(walk_type(context, struct_field_ty, krate)?),
+                ));
+            }
+
+            Ok(FieldType::Struct(name.to_string(), resolved_fields))
+        }
+        StructKind::Plain {
+            fields,
+            has_stripped_fields,
+        } => {
+            assert!(!has_stripped_fields);
+
+            let mut resolved_fields = Vec::with_capacity(fields.len());
+            for field in fields {
+                let struct_field_item = krate.index.get(field).expect("Failed to get field");
+                let ItemEnum::StructField(struct_field_ty) = &struct_field_item.inner else {
+                    panic!("Expected struct field")
+                };
+
+                resolved_fields.push((
+                    struct_field_item.name.clone().unwrap(),
+                    Box::new(walk_type(context, struct_field_ty, krate)?),
+                ));
+            }
+
+            Ok(FieldType::Struct(name.to_string(), resolved_fields))
+        }
+    }
+}
+
+fn verify_enum(context: &Context, name: &str, e: &Enum, krate: &Crate) -> Result<(), Error> {
+    for variant in &e.variants {
+        let variant_item = krate.index.get(variant).expect("Failed to get variant");
+        let ItemEnum::Variant(variant_ty) = &variant_item.inner else {
+            panic!("Expected variant")
+        };
+
+        if variant_ty.kind != VariantKind::Plain {
+            return Err(Error::NonUnitEnum {
+                job: context.current_job.clone(),
+                ty: name.to_string(),
+            });
+        }
+    }
+
+    Ok(())
 }
 
 /// Extracts hooks from a module.
@@ -282,9 +535,8 @@ impl Drop for LockFile {
     }
 }
 
-fn extract_metadata() -> Result<Metadata, Error> {
-    let root = std::env::var("CARGO_MANIFEST_DIR").expect("Failed to get manifest directory");
-    let root = Path::new(&root)
+fn extract_metadata(manifest_dir: &Path) -> Result<Metadata, Error> {
+    let root = Path::new(&manifest_dir)
         .canonicalize()
         .expect("Failed to canonicalize root dir");
 
@@ -331,9 +583,8 @@ fn extract_blueprint_metadata(package: &Package) -> Result<BlueprintMetadata, Er
 }
 
 /// Generates the metadata for the gadget.
-fn generate_gadget(package: &Package) -> Result<Gadget<'static>, Error> {
-    let root = std::env::var("CARGO_MANIFEST_DIR").expect("Failed to get manifest directory");
-    let root = Path::new(&root)
+fn generate_gadget(package: &Package, manifest_dir: &Path) -> Result<Gadget<'static>, Error> {
+    let root = Path::new(&manifest_dir)
         .canonicalize()
         .expect("Failed to canonicalize root dir");
     let mut sources = vec![];
@@ -375,29 +626,27 @@ fn generate_gadget(package: &Package) -> Result<Gadget<'static>, Error> {
     Ok(Gadget::Native(NativeGadget { sources }))
 }
 
-fn generate_rustdoc() -> Result<Crate, Error> {
-    let root = std::env::var("CARGO_MANIFEST_DIR").expect("Failed to get manifest directory");
-    let root = std::path::Path::new(&root);
-    let crate_name = std::env::var("CARGO_PKG_NAME").expect("Failed to get package name");
-    let target_dir = std::env::current_dir()
-        .expect("Failed to get current directory")
-        .join("target");
+fn generate_rustdoc(
+    crate_name: &str,
+    manifest_dir: &Path,
+    target_dir: &Path,
+) -> Result<Crate, Error> {
+    let root = std::path::Path::new(&manifest_dir);
     let lock = LockFile::new(root)?;
     if lock.try_lock().is_err() {
         eprintln!("Already locked; skipping rustdoc generation",);
         // Exit early if the lock file exists
         std::process::exit(0);
     }
-    let custom_target_dir = format!("{}/blueprint", target_dir.display());
     let mut cmd = Command::new("cargo");
 
     cmd.arg("--quiet")
         .arg("rustdoc")
         .args(["-Z", "unstable-options"])
         .args(["--output-format", "json"])
-        .args(["--package", &crate_name])
+        .args(["--package", crate_name])
         .arg("--lib")
-        .args(["--target-dir", &custom_target_dir])
+        .args(["--target-dir", &target_dir.to_string_lossy()])
         .arg("--locked")
         .args(["--", "--document-hidden-items"])
         .env("RUSTC_BOOTSTRAP", "1")
@@ -452,11 +701,14 @@ fn generate_rustdoc() -> Result<Crate, Error> {
             eprintln!("{line}");
         }
         eprintln!("===");
-        panic!("command returned status {status:?}, command was: {final_cmd}")
+        return Err(Error::RustdocFailed {
+            status: status.code(),
+            command: final_cmd,
+        });
     }
 
-    let crate_name_snake_case = kabab_case_to_snake_case(&crate_name);
-    let json_path = format!("{custom_target_dir}/doc/{crate_name_snake_case}.json");
+    let crate_name_snake_case = kabab_case_to_snake_case(crate_name);
+    let json_path = format!("{}/doc/{crate_name_snake_case}.json", target_dir.display());
     eprintln!("Reading JSON from {json_path}");
     let json_string = std::fs::read_to_string(&json_path).expect("Failed to read rustdoc JSON");
     let krate: Crate = serde_json::from_str(&json_string).expect("Failed to parse rustdoc JSON");

--- a/crates/blueprint/metadata/tests/assets/job_enum_param.rs
+++ b/crates/blueprint/metadata/tests/assets/job_enum_param.rs
@@ -1,0 +1,33 @@
+use std::convert::Infallible;
+use blueprint_sdk::event_listeners::tangle::events::TangleEventListener;
+use blueprint_sdk::event_listeners::tangle::services::{services_post_processor, services_pre_processor};
+use blueprint_sdk::macros::contexts::{ServicesContext, TangleClientContext};
+use blueprint_sdk::macros::ext::tangle::tangle_subxt::tangle_testnet_runtime::api::services::events::JobCalled;
+use blueprint_sdk::config::GadgetConfiguration;
+
+#[derive(Clone, TangleClientContext, ServicesContext)]
+pub struct MyContext {
+    #[config]
+    pub env: GadgetConfiguration,
+    #[call_id]
+    pub call_id: Option<u64>,
+}
+
+#[derive(PartialEq)]
+pub enum Status {
+    Failed,
+    Success,
+}
+
+#[blueprint_sdk::job(
+    id = 0,
+    params(status),
+    event_listener(
+        listener = TangleEventListener<MyContext, JobCalled>,
+        pre_processor = services_pre_processor,
+        post_processor = services_post_processor,
+    ),
+)]
+pub fn check_status(status: Status, _context: MyContext) -> Result<bool, Infallible> {
+    Ok(status == Status::Success)
+}

--- a/crates/blueprint/metadata/tests/assets/job_external_type_nested_param.rs
+++ b/crates/blueprint/metadata/tests/assets/job_external_type_nested_param.rs
@@ -1,0 +1,33 @@
+use std::convert::Infallible;
+use blueprint_sdk::event_listeners::tangle::events::TangleEventListener;
+use blueprint_sdk::event_listeners::tangle::services::{services_post_processor, services_pre_processor};
+use blueprint_sdk::macros::contexts::{ServicesContext, TangleClientContext};
+use blueprint_sdk::macros::ext::tangle::tangle_subxt::tangle_testnet_runtime::api::services::events::JobCalled;
+use blueprint_sdk::config::GadgetConfiguration;
+use blueprint_sdk::alloy::primitives::Address;
+
+#[derive(Clone, TangleClientContext, ServicesContext)]
+pub struct MyContext {
+    #[config]
+    pub env: GadgetConfiguration,
+    #[call_id]
+    pub call_id: Option<u64>,
+}
+
+struct SomeParam {
+    a: u32,
+    address: Address,
+}
+
+#[blueprint_sdk::job(
+    id = 0,
+    params(x),
+    event_listener(
+        listener = TangleEventListener<MyContext, JobCalled>,
+        pre_processor = services_pre_processor,
+        post_processor = services_post_processor,
+    ),
+)]
+pub fn address_size(x: SomeParam, _context: MyContext) -> Result<u64, Infallible> {
+    Ok(x.address.len_bytes())
+}

--- a/crates/blueprint/metadata/tests/assets/job_external_type_param.rs
+++ b/crates/blueprint/metadata/tests/assets/job_external_type_param.rs
@@ -1,0 +1,28 @@
+use std::convert::Infallible;
+use blueprint_sdk::event_listeners::tangle::events::TangleEventListener;
+use blueprint_sdk::event_listeners::tangle::services::{services_post_processor, services_pre_processor};
+use blueprint_sdk::macros::contexts::{ServicesContext, TangleClientContext};
+use blueprint_sdk::macros::ext::tangle::tangle_subxt::tangle_testnet_runtime::api::services::events::JobCalled;
+use blueprint_sdk::config::GadgetConfiguration;
+use blueprint_sdk::alloy::primitives::Address;
+
+#[derive(Clone, TangleClientContext, ServicesContext)]
+pub struct MyContext {
+    #[config]
+    pub env: GadgetConfiguration,
+    #[call_id]
+    pub call_id: Option<u64>,
+}
+
+#[blueprint_sdk::job(
+    id = 0,
+    params(x),
+    event_listener(
+        listener = TangleEventListener<MyContext, JobCalled>,
+        pre_processor = services_pre_processor,
+        post_processor = services_post_processor,
+    ),
+)]
+pub fn address_size(x: Address, _context: MyContext) -> Result<u64, Infallible> {
+    Ok(x.len_bytes())
+}

--- a/crates/blueprint/metadata/tests/assets/job_primitive_nested_struct_param.rs
+++ b/crates/blueprint/metadata/tests/assets/job_primitive_nested_struct_param.rs
@@ -1,0 +1,47 @@
+use std::convert::Infallible;
+use blueprint_sdk::event_listeners::tangle::events::TangleEventListener;
+use blueprint_sdk::event_listeners::tangle::services::{services_post_processor, services_pre_processor};
+use blueprint_sdk::macros::contexts::{ServicesContext, TangleClientContext};
+use blueprint_sdk::macros::ext::tangle::tangle_subxt::tangle_testnet_runtime::api::services::events::JobCalled;
+use blueprint_sdk::config::GadgetConfiguration;
+
+#[derive(Clone, TangleClientContext, ServicesContext)]
+pub struct MyContext {
+    #[config]
+    pub env: GadgetConfiguration,
+    #[call_id]
+    pub call_id: Option<u64>,
+}
+
+pub struct SomeParam {
+    pub a: u8,
+    pub nested: SomeNestedParam,
+}
+
+pub struct SomeNestedParam {
+    pub b: u16,
+    pub c: u32,
+    pub d: u64,
+    pub e: u128,
+    pub f: i8,
+    pub g: i16,
+    pub h: i32,
+    pub i: i64,
+    pub j: i128,
+    pub k: f32,
+    pub l: f64,
+    pub m: bool,
+}
+
+#[blueprint_sdk::job(
+    id = 0,
+    params(x),
+    event_listener(
+        listener = TangleEventListener<MyContext, JobCalled>,
+        pre_processor = services_pre_processor,
+        post_processor = services_post_processor,
+    ),
+)]
+pub fn xsquare(x: SomeParam, _context: MyContext) -> Result<u64, Infallible> {
+    Ok(x.nested.d.saturating_pow(2))
+}

--- a/crates/blueprint/metadata/tests/assets/job_primitive_params.rs
+++ b/crates/blueprint/metadata/tests/assets/job_primitive_params.rs
@@ -1,0 +1,27 @@
+use std::convert::Infallible;
+use blueprint_sdk::event_listeners::tangle::events::TangleEventListener;
+use blueprint_sdk::event_listeners::tangle::services::{services_post_processor, services_pre_processor};
+use blueprint_sdk::macros::contexts::{ServicesContext, TangleClientContext};
+use blueprint_sdk::macros::ext::tangle::tangle_subxt::tangle_testnet_runtime::api::services::events::JobCalled;
+use blueprint_sdk::config::GadgetConfiguration;
+
+#[derive(Clone, TangleClientContext, ServicesContext)]
+pub struct MyContext {
+    #[config]
+    pub env: GadgetConfiguration,
+    #[call_id]
+    pub call_id: Option<u64>,
+}
+
+#[blueprint_sdk::job(
+    id = 0,
+    params(x),
+    event_listener(
+        listener = TangleEventListener<MyContext, JobCalled>,
+        pre_processor = services_pre_processor,
+        post_processor = services_post_processor,
+    ),
+)]
+pub fn xsquare(x: u64, _context: MyContext) -> Result<u64, Infallible> {
+    Ok(x.saturating_pow(2))
+}

--- a/crates/blueprint/metadata/tests/assets/job_primitive_struct_param.rs
+++ b/crates/blueprint/metadata/tests/assets/job_primitive_struct_param.rs
@@ -1,0 +1,43 @@
+use std::convert::Infallible;
+use blueprint_sdk::event_listeners::tangle::events::TangleEventListener;
+use blueprint_sdk::event_listeners::tangle::services::{services_post_processor, services_pre_processor};
+use blueprint_sdk::macros::contexts::{ServicesContext, TangleClientContext};
+use blueprint_sdk::macros::ext::tangle::tangle_subxt::tangle_testnet_runtime::api::services::events::JobCalled;
+use blueprint_sdk::config::GadgetConfiguration;
+
+#[derive(Clone, TangleClientContext, ServicesContext)]
+pub struct MyContext {
+    #[config]
+    pub env: GadgetConfiguration,
+    #[call_id]
+    pub call_id: Option<u64>,
+}
+
+pub struct SomeParam {
+    pub a: u8,
+    pub b: u16,
+    pub c: u32,
+    pub d: u64,
+    pub e: u128,
+    pub f: i8,
+    pub g: i16,
+    pub h: i32,
+    pub i: i64,
+    pub j: i128,
+    pub k: f32,
+    pub l: f64,
+    pub m: bool,
+}
+
+#[blueprint_sdk::job(
+    id = 0,
+    params(x),
+    event_listener(
+        listener = TangleEventListener<MyContext, JobCalled>,
+        pre_processor = services_pre_processor,
+        post_processor = services_post_processor,
+    ),
+)]
+pub fn xsquare(x: SomeParam, _context: MyContext) -> Result<u64, Infallible> {
+    Ok(x.d.saturating_pow(2))
+}

--- a/crates/blueprint/metadata/tests/generate.rs
+++ b/crates/blueprint/metadata/tests/generate.rs
@@ -159,3 +159,60 @@ fn generate_job_with_primitive_struct_param() {
         )
     );
 }
+
+#[test]
+fn generate_job_with_primitive_nested_struct_param() {
+    let blueprint = do_test("job_primitive_nested_struct_param");
+    assert_eq!(blueprint.jobs.len(), 1);
+
+    let job = &blueprint.jobs[0];
+    assert_eq!(job.job_id, 0);
+    assert_eq!(job.metadata.name, "xsquare");
+
+    assert_eq!(job.params.len(), 1);
+    assert_eq!(job.params[0].as_rust_type(), "SomeParam");
+
+    let nested_struct = FieldType::Struct(
+        String::from("SomeNestedParam"),
+        vec![
+            (String::from("b"), Box::new(FieldType::Uint16)),
+            (String::from("c"), Box::new(FieldType::Uint32)),
+            (String::from("d"), Box::new(FieldType::Uint64)),
+            (String::from("e"), Box::new(FieldType::Uint128)),
+            (String::from("f"), Box::new(FieldType::Int8)),
+            (String::from("g"), Box::new(FieldType::Int16)),
+            (String::from("h"), Box::new(FieldType::Int32)),
+            (String::from("i"), Box::new(FieldType::Int64)),
+            (String::from("j"), Box::new(FieldType::Int128)),
+            (String::from("k"), Box::new(FieldType::Float64)),
+            (String::from("l"), Box::new(FieldType::Float64)),
+            (String::from("m"), Box::new(FieldType::Bool)),
+        ],
+    );
+
+    assert_eq!(
+        job.params[0],
+        FieldType::Struct(
+            "SomeParam".to_string(),
+            vec![
+                (String::from("a"), Box::new(FieldType::Uint8),),
+                (String::from("nested"), Box::new(nested_struct))
+            ]
+        )
+    );
+}
+
+#[test]
+fn generate_job_with_enum_param() {
+    let blueprint = do_test("job_enum_param");
+    assert_eq!(blueprint.jobs.len(), 1);
+
+    let job = &blueprint.jobs[0];
+    assert_eq!(job.job_id, 0);
+    assert_eq!(job.metadata.name, "check_status");
+
+    assert_eq!(job.params.len(), 1);
+
+    // Enums are represented as strings, since we only support unit variants
+    assert_eq!(job.params[0].as_rust_type(), "String");
+}

--- a/crates/blueprint/metadata/tests/generate.rs
+++ b/crates/blueprint/metadata/tests/generate.rs
@@ -1,0 +1,161 @@
+use blueprint_metadata::Config;
+use gadget_blueprint_proc_macro_core::{FieldType, ServiceBlueprint};
+use std::env::set_current_dir;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+const MANIFEST_META: &str = r#"
+[package.metadata.blueprint]
+manager = { Evm = "DoesntMatter" }
+master_revision = "Latest"
+"#;
+
+fn do_test(asset_name: &str) -> ServiceBlueprint {
+    const PACKAGE_ROOT: &str = env!("CARGO_MANIFEST_DIR");
+
+    let temp = tempfile::tempdir().unwrap();
+    let metadata_output = temp.path().join("blueprint.json");
+
+    set_current_dir(temp.path()).unwrap();
+
+    let out = Command::new("cargo")
+        .args(["init", "--lib", "--name", asset_name])
+        .output()
+        .unwrap();
+
+    if !out.status.success() {
+        panic!("Failed to create new package: {:?}", out);
+    }
+
+    // Copy over the gadget Cargo.lock
+    std::fs::copy(
+        Path::new(PACKAGE_ROOT)
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("Cargo.lock"),
+        temp.path().join("Cargo.lock"),
+    )
+    .unwrap();
+
+    // Add blueprint-sdk to the dependencies, with all features
+    let sdk_path = Path::new(PACKAGE_ROOT)
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("sdk");
+    let out = Command::new("cargo")
+        .args(["add", "blueprint-sdk", "--path"])
+        .arg(sdk_path)
+        .args(["--features", "std,tangle,evm,eigenlayer,macros"])
+        .output()
+        .unwrap();
+
+    if !out.status.success() {
+        panic!("Failed to add blueprint-sdk: {:?}", out);
+    }
+
+    // TODO: Hack
+    /////////
+    let out = Command::new("cargo")
+        .args(["add", "parity-scale-codec@3.6.12"])
+        .output()
+        .unwrap();
+
+    if !out.status.success() {
+        panic!("Failed to add parity-scale-codec: {:?}", out);
+    }
+    //////////
+
+    let src_file_path = temp.path().join("src").join("lib.rs");
+    let mut src_file = OpenOptions::new()
+        .truncate(true)
+        .write(true)
+        .open(src_file_path)
+        .unwrap();
+
+    // Copy over the asset file
+    let asset_file_name = format!("{}.rs", asset_name);
+    let asset_contents = std::fs::read_to_string(
+        Path::new(PACKAGE_ROOT)
+            .join("tests")
+            .join("assets")
+            .join(asset_file_name),
+    )
+    .unwrap();
+    src_file.write_all(asset_contents.as_bytes()).unwrap();
+
+    // Add metadata to the manifest
+    let mut manifest = OpenOptions::new()
+        .append(true)
+        .write(true)
+        .open(temp.path().join("Cargo.toml"))
+        .unwrap();
+    manifest.write_all(MANIFEST_META.as_bytes()).unwrap();
+
+    if let Err(e) = Config::builder()
+        .manifest_dir(temp.path().to_path_buf())
+        .target_dir(temp.path().join("target"))
+        .crate_name(asset_name.to_string())
+        .output_file(metadata_output.clone())
+        .build()
+        .generate_json()
+    {
+        panic!("Failed to generate metadata: {:?}", e);
+    }
+
+    serde_json::from_str(&std::fs::read_to_string(metadata_output).unwrap()).unwrap()
+}
+
+#[test]
+fn generate_job_with_primitive_type_params() {
+    let blueprint = do_test("job_primitive_params");
+    assert_eq!(blueprint.jobs.len(), 1);
+
+    let job = &blueprint.jobs[0];
+    assert_eq!(job.job_id, 0);
+    assert_eq!(job.metadata.name, "xsquare");
+
+    assert_eq!(job.params.len(), 1);
+    assert_eq!(job.params[0].as_rust_type(), "u64");
+}
+
+#[test]
+fn generate_job_with_primitive_struct_param() {
+    let blueprint = do_test("job_primitive_struct_param");
+    assert_eq!(blueprint.jobs.len(), 1);
+
+    let job = &blueprint.jobs[0];
+    assert_eq!(job.job_id, 0);
+    assert_eq!(job.metadata.name, "xsquare");
+
+    assert_eq!(job.params.len(), 1);
+    assert_eq!(job.params[0].as_rust_type(), "SomeParam");
+    assert_eq!(
+        job.params[0],
+        FieldType::Struct(
+            "SomeParam".to_string(),
+            vec![
+                (String::from("a"), Box::new(FieldType::Uint8),),
+                (String::from("b"), Box::new(FieldType::Uint16),),
+                (String::from("c"), Box::new(FieldType::Uint32),),
+                (String::from("d"), Box::new(FieldType::Uint64),),
+                (String::from("e"), Box::new(FieldType::Uint128),),
+                (String::from("f"), Box::new(FieldType::Int8),),
+                (String::from("g"), Box::new(FieldType::Int16),),
+                (String::from("h"), Box::new(FieldType::Int32),),
+                (String::from("i"), Box::new(FieldType::Int64),),
+                (String::from("j"), Box::new(FieldType::Int128),),
+                (String::from("k"), Box::new(FieldType::Float64),),
+                (String::from("l"), Box::new(FieldType::Float64),),
+                (String::from("m"), Box::new(FieldType::Bool),),
+            ]
+        )
+    );
+}

--- a/crates/macros/core/src/lib.rs
+++ b/crates/macros/core/src/lib.rs
@@ -99,7 +99,7 @@ impl FieldType {
             FieldType::Optional(ty) => Cow::Owned(format!("Option<{}>", ty.as_rust_type())),
             FieldType::Array(size, ty) => Cow::Owned(format!("[{}; {size}]", ty.as_rust_type())),
             FieldType::List(ty) => Cow::Owned(format!("Vec<{}>", ty.as_rust_type())),
-            FieldType::Struct(..) => unimplemented!("FieldType::Struct encoding"),
+            FieldType::Struct(name, _) => Cow::Owned(name.clone()),
             FieldType::Tuple(tys) => {
                 let mut s = String::from("(");
                 for ty in tys {


### PR DESCRIPTION
# Overview

This makes it possible to use custom structs and enums as job parameters, and have them be encoded in the `blueprint.json`.

```rust
pub struct SomeStruct {
    pub num: u64,
}

#[blueprint_sdk::job(
    id = 0,
    params(x),
    /* ... */
)]
pub fn xsquare(x: SomeStruct, _context: MyContext) -> Result<u64, Infallible> {
    Ok(x.num.saturating_pow(2))
}
```

## Status

~~This currently doesn't support structs containing external types.~~
This currently doesn't support:
* generic arguments

What *does* work:
* Enums
* Structs with primitives or local types
* External types