### PR TITLE
feat: get blueprint protocol basic summation gossip working

### DIFF
--- a/.cursor/rules/macro.mdc
+++ b/.cursor/rules/macro.mdc
@@ -1,0 +1,118 @@
+---
+description: Rust Macro Expert
+globs: *.rs
+---
+# Rust Macro Development Expert
+
+## Procedural and Derive Macro Development Guidelines
+
+1. **Initial Analysis & Design**
+   - Carefully analyze macro input requirements and syntax constraints
+   - Consider compile-time performance implications
+   - Plan error handling and diagnostic messages
+   - Review existing proc-macro crates before building new ones
+   - Evaluate whether declarative macros (`macro_rules!`) could suffice
+
+2. **Implementation Standards**
+   - Use `syn` for parsing Rust syntax trees
+   - Leverage `quote` for generating Rust code
+   - Implement proper `proc_macro_derive` attributes
+   - Handle edge cases explicitly
+   - Follow naming conventions:
+     - Derive macros: PascalCase
+     - Function-like macros: snake_case
+     - Attribute macros: snake_case
+
+3. **Error Handling & Diagnostics**
+   - Use `proc_macro::Diagnostic` for compiler errors
+   - Implement detailed error messages with span information
+   - Provide helpful suggestions in error messages
+   - Handle parsing failures gracefully
+   - Validate input thoroughly before generation
+
+4. **Code Generation Best Practices**
+   - Generate hygienic identifiers using `format_ident!`
+   - Avoid name collisions with `quote::quote_spanned!`
+   - Maintain proper token spans for error reporting
+   - Generate well-formatted and documented code
+   - Implement Debug/Display traits for custom types
+
+5. **Testing Framework**
+   - Use `trybuild` for compilation tests
+   - Create comprehensive test cases including:
+     - Success cases
+     - Expected failure cases
+     - Edge cases
+     - Syntax variations
+   - Test generated code functionality
+   - Document test cases thoroughly
+
+6. **Performance Considerations**
+   - Minimize allocations during macro expansion
+   - Cache parsed results where appropriate
+   - Use efficient algorithms for syntax tree manipulation
+   - Profile macro expansion time
+   - Consider incremental compilation impact
+
+7. **Documentation Requirements**
+   - Document macro syntax and usage
+   - Provide clear examples
+   - Explain generated code behavior
+   - Document any assumptions or limitations
+   - Include common pitfalls and solutions
+
+8. **Advanced Features**
+   - Custom derive helper attributes
+   - Nested attribute handling
+   - Cross-platform compatibility
+   - Integration with existing traits
+   - Custom keyword parsing
+
+9. **Security & Safety**
+   - Validate all inputs thoroughly
+   - Avoid executing arbitrary code
+   - Maintain type safety in generated code
+   - Handle visibility modifiers correctly
+   - Respect macro hygiene rules
+
+10. **Debugging Support**
+    - Implement `#[derive(Debug)]` where appropriate
+    - Add trace logging for development
+    - Support for cargo-expand
+    - Generate readable code
+    - Maintain source mappings
+
+11. **Common Patterns**
+    - Builder pattern generation
+    - Trait implementation automation
+    - Serialization/Deserialization
+    - Custom DSL parsing
+    - Attribute forwarding
+
+12. **Integration Guidelines**
+    - Proper dependency specification
+    - Version compatibility
+    - Feature flag organization
+    - Re-export convenience
+    - Documentation of integration points
+
+13. **Maintenance Considerations**
+    - Semantic versioning adherence
+    - Breaking change management
+    - Deprecation strategies
+    - Upgrade paths
+    - Backward compatibility
+
+14. **Optimization Techniques**
+    - Token stream pre-processing
+    - Lazy evaluation strategies
+    - Compile-time computation
+    - Code generation optimization
+    - Memory usage optimization
+
+15. **Quality Assurance**
+    - Continuous Integration setup
+    - Cross-platform testing
+    - Documentation testing
+    - API stability testing
+    - Performance benchmarking

--- a/crates/networking/src/tests/blueprint_protocol.rs
+++ b/crates/networking/src/tests/blueprint_protocol.rs
@@ -1,564 +1,415 @@
-// TODO
-// use gadget_crypto::KeyType;
-// use libp2p::PeerId;
-// use serde::{Deserialize, Serialize};
-// use std::{collections::HashSet, time::Duration};
-// use tokio::time::timeout;
-// use tracing::info;
-//
-// use crate::{
-//     blueprint_protocol::{InstanceMessageRequest, InstanceMessageResponse},
-//     key_types::{Curve, InstanceMsgKeyPair, InstanceMsgPublicKey},
-//     service::NetworkMessage,
-//     service_handle::NetworkServiceHandle,
-//     tests::{
-//         create_whitelisted_nodes, wait_for_all_handshakes, wait_for_handshake_completion, TestNode,
-//     },
-//     types::{MessageRouting, ParticipantId, ParticipantInfo, ProtocolMessage},
-// };
-//
-// const TEST_TIMEOUT: Duration = Duration::from_secs(10);
-// const PROTOCOL_NAME: &str = "summation/1.0.0";
-//
-// // Protocol message types
-// #[derive(Debug, Clone, Serialize, Deserialize)]
-// enum SummationMessage {
-//     Number(u64),
-//     Verification { sum: u64 },
-// }
-//
-// // Helper to create a protocol message
-// fn create_protocol_message(
-//     protocol: &str,
-//     msg: SummationMessage,
-//     sender: &NetworkServiceHandle,
-//     recipient: Option<PeerId>,
-// ) -> ProtocolMessage {
-//     ProtocolMessage {
-//         protocol: protocol.to_string(),
-//         routing: MessageRouting {
-//             message_id: 0,
-//             round_id: 0,
-//             sender: ParticipantInfo {
-//                 id: ParticipantId(0),
-//                 public_key: None,
-//             },
-//             recipient: recipient.map(|peer_id| ParticipantInfo {
-//                 id: ParticipantId(0),
-//                 public_key: None,
-//             }),
-//         },
-//         payload: bincode::serialize(&msg).expect("Failed to serialize message"),
-//     }
-// }
-//
-// // Helper to extract number from message
-// fn extract_number_from_message(msg: &ProtocolMessage) -> u64 {
-//     match bincode::deserialize::<SummationMessage>(&msg.payload).expect("Failed to deserialize") {
-//         SummationMessage::Number(n) => n,
-//         _ => panic!("Expected number message"),
-//     }
-// }
-//
-// // Helper to extract sum from verification message
-// fn extract_sum_from_verification(msg: &ProtocolMessage) -> u64 {
-//     match bincode::deserialize::<SummationMessage>(&msg.payload).expect("Failed to deserialize") {
-//         SummationMessage::Verification { sum } => sum,
-//         _ => panic!("Expected verification message"),
-//     }
-// }
-//
-// #[tokio::test]
-// async fn test_summation_protocol_basic() {
-//     super::init_tracing();
-//     info!("Starting summation protocol test");
-//
-//     // Create nodes with whitelisted keys
-//     let instance_key_pair2 = Curve::generate_with_seed(None).unwrap();
-//     let mut allowed_keys1 = HashSet::new();
-//     allowed_keys1.insert(instance_key_pair2.public());
-//
-//     let mut node1 = TestNode::new("test-net", "sum-test", allowed_keys1, vec![]).await;
-//
-//     let mut allowed_keys2 = HashSet::new();
-//     allowed_keys2.insert(node1.instance_key_pair.public());
-//     let mut node2 = TestNode::new_with_keys(
-//         "test-net",
-//         "sum-test",
-//         allowed_keys2,
-//         vec![],
-//         Some(instance_key_pair2),
-//         None,
-//     )
-//     .await;
-//
-//     info!("Starting nodes");
-//     let mut handle1 = node1.start().await.expect("Failed to start node1");
-//     let mut handle2 = node2.start().await.expect("Failed to start node2");
-//
-//     info!("Waiting for handshake completion");
-//     wait_for_handshake_completion(&handle1, &handle2, TEST_TIMEOUT).await;
-//
-//     // Generate test numbers
-//     let num1 = 42;
-//     let num2 = 58;
-//     let expected_sum = num1 + num2;
-//
-//     info!("Sending numbers via gossip");
-//     // Send numbers via gossip
-//     handle1
-//         .send(create_protocol_message(
-//             PROTOCOL_NAME,
-//             SummationMessage::Number(num1),
-//             &handle1,
-//             None,
-//         ))
-//         .expect("Failed to send number from node1");
-//
-//     handle2
-//         .send(create_protocol_message(
-//             PROTOCOL_NAME,
-//             SummationMessage::Number(num2),
-//             &handle2,
-//             None,
-//         ))
-//         .expect("Failed to send number from node2");
-//
-//     info!("Waiting for messages to be processed");
-//     // Wait for messages and compute sums
-//     let mut sum1 = 0;
-//     let mut sum2 = 0;
-//     let mut node1_received = false;
-//     let mut node2_received = false;
-//
-//     timeout(TEST_TIMEOUT, async {
-//         loop {
-//             // Process incoming messages
-//             if let Some(msg) = handle1.next_protocol_message() {
-//                 if !node1_received {
-//                     sum1 += extract_number_from_message(&msg);
-//                     node1_received = true;
-//                 }
-//             }
-//             if let Some(msg) = handle2.next_protocol_message() {
-//                 if !node2_received {
-//                     sum2 += extract_number_from_message(&msg);
-//                     node2_received = true;
-//                 }
-//             }
-//
-//             // Check if both nodes have received messages
-//             if node1_received && node2_received {
-//                 break;
-//             }
-//             tokio::time::sleep(Duration::from_millis(100)).await;
-//         }
-//     })
-//     .await
-//     .expect("Timeout waiting for summation completion");
-//
-//     info!("Verifying sums via P2P messages");
-//     // Verify sums via P2P messages
-//     handle1
-//         .send(create_protocol_message(
-//             PROTOCOL_NAME,
-//             SummationMessage::Verification { sum: sum1 },
-//             &handle1,
-//             Some(node2.peer_id),
-//         ))
-//         .expect("Failed to send verification from node1");
-//
-//     handle2
-//         .send(create_protocol_message(
-//             PROTOCOL_NAME,
-//             SummationMessage::Verification { sum: sum2 },
-//             &handle2,
-//             Some(node1.peer_id),
-//         ))
-//         .expect("Failed to send verification from node2");
-//
-//     info!("Waiting for verification messages");
-//     // Wait for verification messages
-//     timeout(TEST_TIMEOUT, async {
-//         let mut node1_verified = false;
-//         let mut node2_verified = false;
-//
-//         loop {
-//             // Process verification messages
-//             if let Some(msg) = handle1.next_protocol_message() {
-//                 if !node1_verified {
-//                     assert_eq!(extract_sum_from_verification(&msg), expected_sum);
-//                     node1_verified = true;
-//                 }
-//             }
-//             if let Some(msg) = handle2.next_protocol_message() {
-//                 if !node2_verified {
-//                     assert_eq!(extract_sum_from_verification(&msg), expected_sum);
-//                     node2_verified = true;
-//                 }
-//             }
-//
-//             if node1_verified && node2_verified {
-//                 break;
-//             }
-//             tokio::time::sleep(Duration::from_millis(100)).await;
-//         }
-//     })
-//     .await
-//     .expect("Timeout waiting for verification completion");
-//
-//     info!("Summation protocol test completed successfully");
-// }
-//
-// #[tokio::test]
-// async fn test_summation_protocol_multi_node() {
-//     super::init_tracing();
-//     info!("Starting multi-node summation protocol test");
-//
-//     // Create 3 nodes with whitelisted keys
-//     info!("Creating whitelisted nodes");
-//     let mut nodes = create_whitelisted_nodes(3).await;
-//     info!("Created {} nodes successfully", nodes.len());
-//
-//     // Start all nodes
-//     info!("Starting all nodes");
-//     let mut handles = Vec::new();
-//     for (i, node) in nodes.iter_mut().enumerate() {
-//         info!("Starting node {}", i);
-//         handles.push(node.start().await.expect("Failed to start node"));
-//         info!("Node {} started successfully", i);
-//     }
-//
-//     // Convert handles to mutable references
-//     info!("Converting handles to mutable references");
-//     let mut handles: Vec<&mut NetworkServiceHandle> = handles.iter_mut().collect();
-//     let handles_len = handles.len();
-//     info!("Converted {} handles", handles_len);
-//
-//     // Wait for all handshakes to complete
-//     info!(
-//         "Waiting for handshake completion between {} nodes",
-//         handles_len
-//     );
-//     wait_for_all_handshakes(&handles, TEST_TIMEOUT).await;
-//     info!("All handshakes completed successfully");
-//
-//     // Generate test numbers
-//     let numbers = vec![42, 58, 100];
-//     let expected_sum: u64 = numbers.iter().sum();
-//     info!(
-//         "Generated test numbers: {:?}, expected sum: {}",
-//         numbers, expected_sum
-//     );
-//
-//     info!("Sending numbers via gossip");
-//     // Each node broadcasts its number
-//     for (i, handle) in handles.iter().enumerate() {
-//         info!("Node {} broadcasting number {}", i, numbers[i]);
-//         handle
-//             .send(create_protocol_message(
-//                 PROTOCOL_NAME,
-//                 SummationMessage::Number(numbers[i]),
-//                 handle,
-//                 None,
-//             ))
-//             .expect("Failed to send number");
-//         info!("Node {} successfully broadcast its number", i);
-//         // Add a small delay between broadcasts to avoid message collisions
-//         tokio::time::sleep(Duration::from_millis(100)).await;
-//     }
-//
-//     info!("Waiting for messages to be processed");
-//     // Wait for all nodes to receive all numbers
-//     let mut sums = vec![0; handles_len];
-//     let mut received = vec![0; handles_len];
-//
-//     timeout(TEST_TIMEOUT, async {
-//         loop {
-//             for (i, handle) in handles.iter_mut().enumerate() {
-//                 if let Some(msg) = handle.next_protocol_message() {
-//                     if received[i] < handles_len - 1 {
-//                         let num = extract_number_from_message(&msg);
-//                         sums[i] += num;
-//                         received[i] += 1;
-//                         info!(
-//                             "Node {} received number {}, total sum: {}, received count: {}",
-//                             i, num, sums[i], received[i]
-//                         );
-//                     }
-//                 }
-//             }
-//
-//             let all_received = received.iter().all(|&r| r == handles_len - 1);
-//             info!(
-//                 "Current received counts: {:?}, target count: {}",
-//                 received,
-//                 handles_len - 1
-//             );
-//             if all_received {
-//                 info!("All nodes have received all numbers");
-//                 break;
-//             }
-//             tokio::time::sleep(Duration::from_millis(100)).await;
-//         }
-//     })
-//     .await
-//     .expect("Timeout waiting for summation completion");
-//
-//     info!("Verifying sums via P2P messages");
-//     info!("Final sums: {:?}", sums);
-//     // Each node verifies with every other node
-//     for (i, sender) in handles.iter().enumerate() {
-//         for (j, recipient) in handles.iter().enumerate() {
-//             if i != j {
-//                 info!(
-//                     "Node {} sending verification sum {} to node {}",
-//                     i, sums[i], j
-//                 );
-//                 sender
-//                     .send(create_protocol_message(
-//                         PROTOCOL_NAME,
-//                         SummationMessage::Verification { sum: sums[i] },
-//                         sender,
-//                         Some(recipient.local_peer_id),
-//                     ))
-//                     .expect("Failed to send verification");
-//             }
-//         }
-//     }
-//
-//     info!("Waiting for verification messages");
-//     // Wait for all verifications
-//     timeout(TEST_TIMEOUT, async {
-//         let mut verified = vec![0; handles_len];
-//         loop {
-//             for (i, handle) in handles.iter_mut().enumerate() {
-//                 if let Some(msg) = handle.next_protocol_message() {
-//                     if verified[i] < handles_len - 1 {
-//                         let sum = extract_sum_from_verification(&msg);
-//                         info!(
-//                             "Node {} received verification sum {}, expected {}",
-//                             i, sum, expected_sum
-//                         );
-//                         assert_eq!(sum, expected_sum);
-//                         verified[i] += 1;
-//                         info!("Node {} verification count: {}", i, verified[i]);
-//                     }
-//                 }
-//             }
-//
-//             let all_verified = verified.iter().all(|&v| v == handles_len - 1);
-//             info!("Current verification counts: {:?}", verified);
-//             if all_verified {
-//                 info!("All nodes have verified all sums");
-//                 break;
-//             }
-//             tokio::time::sleep(Duration::from_millis(100)).await;
-//         }
-//     })
-//     .await
-//     .expect("Timeout waiting for verification completion");
-//
-//     info!("Multi-node summation protocol test completed successfully");
-// }
-//
-// #[tokio::test]
-// async fn test_summation_protocol_late_join() {
-//     super::init_tracing();
-//     info!("Starting late join summation protocol test");
-//
-//     // Create 3 nodes but only start 2 initially
-//     let mut nodes = create_whitelisted_nodes(3).await;
-//
-//     // Start first two nodes
-//     let mut handles = Vec::new();
-//     for node in nodes[..2].iter_mut() {
-//         handles.push(node.start().await.expect("Failed to start node"));
-//     }
-//
-//     // Convert handles to mutable references
-//     let handles_refs: Vec<&mut NetworkServiceHandle> = handles.iter_mut().collect();
-//
-//     // Wait for initial handshakes
-//     info!("Waiting for initial handshake completion");
-//     wait_for_all_handshakes(&handles_refs, TEST_TIMEOUT).await;
-//
-//     // Initial nodes send their numbers
-//     let numbers = vec![42, 58, 100];
-//     let _expected_sum: u64 = numbers.iter().sum();
-//
-//     info!("Initial nodes sending numbers");
-//     for (i, handle) in handles.iter().enumerate() {
-//         handle
-//             .send(create_protocol_message(
-//                 PROTOCOL_NAME,
-//                 SummationMessage::Number(numbers[i]),
-//                 handle,
-//                 None,
-//             ))
-//             .expect("Failed to send number");
-//     }
-//
-//     // Wait for initial nodes to process messages
-//     timeout(TEST_TIMEOUT, async {
-//         let mut received = vec![false; 2];
-//         loop {
-//             for (i, handle) in handles.iter_mut().enumerate() {
-//                 if let Some(msg) = handle.next_protocol_message() {
-//                     if !received[i] {
-//                         assert_eq!(extract_number_from_message(&msg), numbers[1 - i]);
-//                         received[i] = true;
-//                     }
-//                 }
-//             }
-//             if received.iter().all(|&r| r) {
-//                 break;
-//             }
-//             tokio::time::sleep(Duration::from_millis(100)).await;
-//         }
-//     })
-//     .await
-//     .expect("Timeout waiting for initial summation");
-//
-//     // Start the late joining node
-//     info!("Starting late joining node");
-//     handles.push(nodes[2].start().await.expect("Failed to start late node"));
-//     let all_handles: Vec<&mut NetworkServiceHandle> = handles.iter_mut().collect();
-//
-//     // Wait for the new node to complete handshakes
-//     wait_for_all_handshakes(&all_handles, TEST_TIMEOUT).await;
-//
-//     // Late node sends its number and receives history
-//     info!("Late node sending number and receiving history");
-//     handles[2]
-//         .send(create_protocol_message(
-//             PROTOCOL_NAME,
-//             SummationMessage::Number(numbers[2]),
-//             &handles[2],
-//             None,
-//         ))
-//         .expect("Failed to send number from late node");
-//
-//     // Verify final state
-//     timeout(TEST_TIMEOUT, async {
-//         let mut verified = vec![false; handles.len()];
-//         loop {
-//             for (i, handle) in handles.iter_mut().enumerate() {
-//                 if let Some(msg) = handle.next_protocol_message() {
-//                     let num = extract_number_from_message(&msg);
-//                     if !verified[i] && (num == numbers[2] || numbers.contains(&num)) {
-//                         verified[i] = true;
-//                     }
-//                 }
-//             }
-//             if verified.iter().all(|&v| v) {
-//                 break;
-//             }
-//             tokio::time::sleep(Duration::from_millis(100)).await;
-//         }
-//     })
-//     .await
-//     .expect("Timeout waiting for late node synchronization");
-//
-//     info!("Late join test completed successfully");
-// }
-//
-// #[tokio::test]
-// async fn test_summation_protocol_node_disconnect() {
-//     super::init_tracing();
-//     info!("Starting node disconnect test");
-//
-//     // Create 3 nodes
-//     let mut nodes = create_whitelisted_nodes(3).await;
-//
-//     // Start all nodes
-//     let mut handles = Vec::new();
-//     for node in nodes.iter_mut() {
-//         handles.push(node.start().await.expect("Failed to start node"));
-//     }
-//
-//     // Convert handles to mutable references
-//     let handles_refs: Vec<&mut NetworkServiceHandle> = handles.iter_mut().collect();
-//
-//     // Wait for all handshakes
-//     wait_for_all_handshakes(&handles_refs, TEST_TIMEOUT).await;
-//
-//     // Send initial numbers
-//     let numbers = vec![42, 58, 100];
-//     for (i, handle) in handles.iter().enumerate() {
-//         handle
-//             .send(create_protocol_message(
-//                 PROTOCOL_NAME,
-//                 SummationMessage::Number(numbers[i]),
-//                 handle,
-//                 None,
-//             ))
-//             .expect("Failed to send number");
-//     }
-//
-//     // Wait for initial processing
-//     timeout(TEST_TIMEOUT, async {
-//         let mut received = vec![0; handles.len()];
-//         loop {
-//             for (i, handle) in handles.iter_mut().enumerate() {
-//                 if let Some(msg) = handle.next_protocol_message() {
-//                     if received[i] < 2 {
-//                         extract_number_from_message(&msg);
-//                         received[i] += 1;
-//                     }
-//                 }
-//             }
-//             if received.iter().all(|&r| r == 2) {
-//                 break;
-//             }
-//             tokio::time::sleep(Duration::from_millis(100)).await;
-//         }
-//     })
-//     .await
-//     .expect("Timeout waiting for initial messages");
-//
-//     // Disconnect one node
-//     info!("Disconnecting node");
-//     drop(handles.pop());
-//     let mut remaining_handles: Vec<&mut NetworkServiceHandle> = handles.iter_mut().collect();
-//
-//     // Verify remaining nodes can still communicate
-//     info!("Verifying remaining nodes can communicate");
-//     for (i, sender) in remaining_handles.iter().enumerate() {
-//         for (j, recipient) in remaining_handles.iter().enumerate() {
-//             if i != j {
-//                 sender
-//                     .send(create_protocol_message(
-//                         PROTOCOL_NAME,
-//                         SummationMessage::Verification { sum: numbers[i] },
-//                         sender,
-//                         Some(recipient.local_peer_id),
-//                     ))
-//                     .expect("Failed to send verification");
-//             }
-//         }
-//     }
-//
-//     // Wait for verification messages
-//     timeout(TEST_TIMEOUT, async {
-//         let mut verified = vec![false; remaining_handles.len()];
-//         loop {
-//             for (i, handle) in remaining_handles.iter_mut().enumerate() {
-//                 if let Some(msg) = handle.next_protocol_message() {
-//                     if !verified[i] {
-//                         extract_sum_from_verification(&msg);
-//                         verified[i] = true;
-//                     }
-//                 }
-//             }
-//             if verified.iter().all(|&v| v) {
-//                 break;
-//             }
-//             tokio::time::sleep(Duration::from_millis(100)).await;
-//         }
-//     })
-//     .await
-//     .expect("Timeout waiting for verification after disconnect");
-//
-//     info!("Node disconnect test completed successfully");
-// }
+use crate::{
+    key_types::Curve,
+    service_handle::NetworkServiceHandle,
+    tests::{
+        create_whitelisted_nodes, wait_for_all_handshakes, wait_for_handshake_completion, TestNode,
+    },
+    types::{MessageRouting, ParticipantId, ParticipantInfo, ProtocolMessage},
+};
+use gadget_crypto::KeyType;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashSet, time::Duration};
+use tokio::time::timeout;
+use tracing::info;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+const PROTOCOL_NAME: &str = "summation/1.0.0";
+
+// Protocol message types
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum SummationMessage {
+    Number(u64),
+    Verification { sum: u64 },
+}
+
+// Helper to create a protocol message
+fn create_protocol_message<T: Serialize>(
+    message: T,
+    message_id: u64,
+    round_id: u16,
+    sender: ParticipantInfo,
+    target_peer: Option<ParticipantInfo>,
+) -> (MessageRouting, Vec<u8>) {
+    let payload = bincode::serialize(&message).expect("Failed to serialize message");
+    let routing = MessageRouting {
+        message_id,
+        round_id,
+        sender,
+        recipient: target_peer,
+    };
+    (routing, payload)
+}
+
+// Helper to extract number from message
+fn extract_number_from_message(msg: &ProtocolMessage) -> u64 {
+    match bincode::deserialize::<SummationMessage>(&msg.payload).expect("Failed to deserialize") {
+        SummationMessage::Number(n) => n,
+        _ => panic!("Expected number message"),
+    }
+}
+
+// Helper to extract sum from verification message
+fn extract_sum_from_verification(msg: &ProtocolMessage) -> u64 {
+    match bincode::deserialize::<SummationMessage>(&msg.payload).expect("Failed to deserialize") {
+        SummationMessage::Verification { sum } => sum,
+        _ => panic!("Expected verification message"),
+    }
+}
+
+#[tokio::test]
+async fn test_summation_protocol_basic() {
+    super::init_tracing();
+    info!("Starting summation protocol test");
+
+    // Create nodes with whitelisted keys
+    let instance_key_pair2 = Curve::generate_with_seed(None).unwrap();
+    let mut allowed_keys1 = HashSet::new();
+    allowed_keys1.insert(instance_key_pair2.public());
+
+    let mut node1 = TestNode::new("test-net", "sum-test", allowed_keys1, vec![]);
+
+    let mut allowed_keys2 = HashSet::new();
+    allowed_keys2.insert(node1.instance_key_pair.public());
+    let mut node2 = TestNode::new_with_keys(
+        "test-net",
+        "sum-test",
+        allowed_keys2,
+        vec![],
+        Some(instance_key_pair2),
+        None,
+    );
+
+    info!("Starting nodes");
+    let mut handle1 = node1.start().await.expect("Failed to start node1");
+    let mut handle2 = node2.start().await.expect("Failed to start node2");
+
+    info!("Waiting for handshake completion");
+    wait_for_handshake_completion(&handle1, &handle2, TEST_TIMEOUT).await;
+
+    // ----------------------------------------------
+    //     ROUND 1: GENERATE NUMBERS AND GOSSIP
+    // ----------------------------------------------
+    // Generate test numbers
+    let num1 = 42;
+    let num2 = 58;
+    let expected_sum = num1 + num2;
+    let message_id = 0;
+    let round_id = 0;
+
+    info!("Sending numbers via gossip");
+    // Send numbers via gossip from node1 handle1
+    let (routing, payload) = create_protocol_message(
+        SummationMessage::Number(num1),
+        message_id,
+        round_id,
+        ParticipantInfo {
+            id: ParticipantId(1),
+            public_key: Some(node1.instance_key_pair.public()),
+        },
+        None,
+    );
+    handle1
+        .send(routing, payload)
+        .expect("Failed to send number from node1");
+
+    // Send numbers via gossip from node2 handle2
+    let (routing, payload) = create_protocol_message(
+        SummationMessage::Number(num2),
+        message_id,
+        round_id,
+        ParticipantInfo {
+            id: ParticipantId(2),
+            public_key: Some(node2.instance_key_pair.public()),
+        },
+        None,
+    );
+    handle2
+        .send(routing, payload)
+        .expect("Failed to send number from node2");
+
+    info!("Waiting for messages to be processed");
+
+    // Wait for messages and compute sums
+    let mut sum1 = num1;
+    let mut sum2 = num2;
+    let mut node1_received = false;
+    let mut node2_received = false;
+
+    timeout(TEST_TIMEOUT, async {
+        loop {
+            // Process incoming messages
+            if let Some(msg) = handle1.next_protocol_message() {
+                if !node1_received {
+                    sum1 += extract_number_from_message(&msg);
+                    node1_received = true;
+                }
+            }
+            if let Some(msg) = handle2.next_protocol_message() {
+                if !node2_received {
+                    sum2 += extract_number_from_message(&msg);
+                    node2_received = true;
+                }
+            }
+
+            // Check if both nodes have received messages
+            if node1_received && node2_received {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("Timeout waiting for summation completion");
+
+    /// --------------------------------------------- ///
+    ///      ROUND 2: VERIFY NUMBERS AND GOSSIP
+    /// --------------------------------------------- ///
+    let message_id = 1;
+    let round_id = 1;
+
+    info!("Verifying sums via P2P messages");
+    // Verify sums via P2P messages
+    let (routing, payload) = create_protocol_message(
+        SummationMessage::Verification { sum: sum1 },
+        message_id,
+        round_id,
+        ParticipantInfo {
+            id: ParticipantId(1),
+            public_key: Some(node1.instance_key_pair.public()),
+        },
+        Some(ParticipantInfo {
+            id: ParticipantId(2),
+            public_key: Some(node2.instance_key_pair.public()),
+        }),
+    );
+    handle1
+        .send(routing, payload)
+        .expect("Failed to send verification from node1");
+
+    let (routing, payload) = create_protocol_message(
+        SummationMessage::Verification { sum: sum2 },
+        message_id,
+        round_id,
+        ParticipantInfo {
+            id: ParticipantId(2),
+            public_key: Some(node2.instance_key_pair.public()),
+        },
+        Some(ParticipantInfo {
+            id: ParticipantId(1),
+            public_key: Some(node1.instance_key_pair.public()),
+        }),
+    );
+    handle2
+        .send(routing, payload)
+        .expect("Failed to send verification from node2");
+
+    info!("Waiting for verification messages");
+    // Wait for verification messages
+    timeout(TEST_TIMEOUT, async {
+        let mut node1_verified = false;
+        let mut node2_verified = false;
+
+        loop {
+            // Process verification messages
+            if let Some(msg) = handle1.next_protocol_message() {
+                if !node1_verified {
+                    assert_eq!(extract_sum_from_verification(&msg), expected_sum);
+                    node1_verified = true;
+                }
+            }
+            if let Some(msg) = handle2.next_protocol_message() {
+                if !node2_verified {
+                    assert_eq!(extract_sum_from_verification(&msg), expected_sum);
+                    node2_verified = true;
+                }
+            }
+
+            if node1_verified && node2_verified {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("Timeout waiting for verification completion");
+
+    info!("Summation protocol test completed successfully");
+}
+
+#[tokio::test]
+async fn test_summation_protocol_multi_node() {
+    super::init_tracing();
+    info!("Starting multi-node summation protocol test");
+
+    // Create 3 nodes with whitelisted keys
+    info!("Creating whitelisted nodes");
+    let mut nodes = create_whitelisted_nodes(3).await;
+    info!("Created {} nodes successfully", nodes.len());
+
+    // Start all nodes
+    info!("Starting all nodes");
+    let mut handles = Vec::new();
+    for (i, node) in nodes.iter_mut().enumerate() {
+        info!("Starting node {}", i);
+        handles.push(node.start().await.expect("Failed to start node"));
+        info!("Node {} started successfully", i);
+    }
+
+    // Convert handles to mutable references
+    info!("Converting handles to mutable references");
+    let mut handles: Vec<&mut NetworkServiceHandle> = handles.iter_mut().collect();
+    let handles_len = handles.len();
+    info!("Converted {} handles", handles_len);
+
+    // Wait for all handshakes to complete
+    info!(
+        "Waiting for handshake completion between {} nodes",
+        handles_len
+    );
+    wait_for_all_handshakes(&handles, TEST_TIMEOUT).await;
+    info!("All handshakes completed successfully");
+
+    // ----------------------------------------------
+    //     ROUND 1: GENERATE NUMBERS AND GOSSIP
+    // ----------------------------------------------
+
+    // Generate test numbers
+    let numbers = vec![42, 58, 100];
+    let expected_sum: u64 = numbers.iter().sum();
+    let message_id = 0;
+    let round_id = 0;
+    info!(
+        "Generated test numbers: {:?}, expected sum: {}",
+        numbers, expected_sum
+    );
+
+    info!("Sending numbers via gossip");
+    // Each node broadcasts its number
+    for (i, handle) in handles.iter().enumerate() {
+        info!("Node {} broadcasting number {}", i, numbers[i]);
+        let (routing, payload) = create_protocol_message(
+            SummationMessage::Number(numbers[i]),
+            message_id,
+            round_id,
+            ParticipantInfo {
+                id: ParticipantId(i as u16),
+                public_key: Some(nodes[i].instance_key_pair.public()),
+            },
+            None,
+        );
+        handle
+            .send(routing, payload)
+            .expect("Failed to send number");
+        info!("Node {} successfully broadcast its number", i);
+        // Add a small delay between broadcasts to avoid message collisions
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    info!("Waiting for messages to be processed");
+
+    // Wait for all nodes to receive all numbers
+    let mut sums = numbers.clone();
+    let mut received = vec![0; handles_len];
+
+    timeout(TEST_TIMEOUT, async {
+        loop {
+            for (i, handle) in handles.iter_mut().enumerate() {
+                if let Some(msg) = handle.next_protocol_message() {
+                    if received[i] < handles_len - 1 {
+                        let num = extract_number_from_message(&msg);
+                        sums[i] += num;
+                        received[i] += 1;
+                        info!(
+                            "Node {} received number {}, total sum: {}, received count: {}",
+                            i, num, sums[i], received[i]
+                        );
+                    }
+                }
+            }
+
+            let all_received = received.iter().all(|&r| r == handles_len - 1);
+            info!(
+                "Current received counts: {:?}, target count: {}",
+                received,
+                handles_len - 1
+            );
+            if all_received {
+                info!("All nodes have received all numbers");
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("Timeout waiting for summation completion");
+
+    // -------------------------------------------------
+    //      ROUND 2: VERIFY NUMBERS AND GOSSIP
+    // -------------------------------------------------
+    let message_id = 1;
+    let round_id = 1;
+
+    info!("Verifying sums via P2P messages");
+    info!("Final sums: {:?}", sums);
+    // Each node verifies with every other node
+    for (i, sender) in handles.iter().enumerate() {
+        for (j, recipient) in handles.iter().enumerate() {
+            if i != j {
+                info!(
+                    "Node {} sending verification sum {} to node {}",
+                    i, sums[i], j
+                );
+                let (routing, payload) = create_protocol_message(
+                    SummationMessage::Verification { sum: sums[i] },
+                    message_id,
+                    round_id,
+                    ParticipantInfo {
+                        id: ParticipantId(i as u16),
+                        public_key: Some(nodes[i].instance_key_pair.public()),
+                    },
+                    Some(ParticipantInfo {
+                        id: ParticipantId(j as u16),
+                        public_key: Some(nodes[j].instance_key_pair.public()),
+                    }),
+                );
+                sender
+                    .send(routing, payload)
+                    .expect("Failed to send verification");
+            }
+        }
+    }
+
+    info!("Waiting for verification messages");
+    // Wait for all verifications
+    timeout(TEST_TIMEOUT, async {
+        let mut verified = vec![0; handles_len];
+        loop {
+            for (i, handle) in handles.iter_mut().enumerate() {
+                if let Some(msg) = handle.next_protocol_message() {
+                    if verified[i] < handles_len - 1 {
+                        let sum = extract_sum_from_verification(&msg);
+                        info!(
+                            "Node {} received verification sum {}, expected {}",
+                            i, sum, expected_sum
+                        );
+                        assert_eq!(sum, expected_sum);
+                        verified[i] += 1;
+                        info!("Node {} verification count: {}", i, verified[i]);
+                    }
+                }
+            }
+
+            let all_verified = verified.iter().all(|&v| v == handles_len - 1);
+            info!("Current verification counts: {:?}", verified);
+            if all_verified {
+                info!("All nodes have verified all sums");
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("Timeout waiting for verification completion");
+
+    info!("Multi-node summation protocol test completed successfully");
+}

--- a/crates/testing-utils/core/src/runner.rs
+++ b/crates/testing-utils/core/src/runner.rs
@@ -6,7 +6,7 @@ use gadget_runners::core::runner::{BackgroundService, BlueprintRunner};
 
 #[derive(Clone)]
 pub struct TestRunner {
-    inner: BlueprintRunner,
+    pub inner: BlueprintRunner,
 }
 
 impl TestRunner {

--- a/crates/testing-utils/eigenlayer/src/runner.rs
+++ b/crates/testing-utils/eigenlayer/src/runner.rs
@@ -11,10 +11,10 @@ use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
 pub struct EigenlayerBLSTestEnv {
-    runner: TestRunner,
-    config: EigenlayerBLSConfig,
-    gadget_config: GadgetConfiguration,
-    runner_handle: Mutex<Option<JoinHandle<Result<(), Error>>>>,
+    pub runner: TestRunner,
+    pub config: EigenlayerBLSConfig,
+    pub gadget_config: GadgetConfiguration,
+    pub runner_handle: Mutex<Option<JoinHandle<Result<(), Error>>>>,
 }
 
 impl TestEnv for EigenlayerBLSTestEnv {

--- a/crates/testing-utils/tangle/src/multi_node.rs
+++ b/crates/testing-utils/tangle/src/multi_node.rs
@@ -25,23 +25,23 @@ use tangle_subxt::subxt::tx::Signer;
 use tokio::sync::{broadcast, mpsc, oneshot, RwLock};
 
 #[derive(Clone, Debug)]
-enum NodeSlot {
+pub enum NodeSlot {
     Occupied(Arc<NodeHandle>),
     Empty,
 }
 
 /// Improved multi-node test environment with better control and observability
 pub struct MultiNodeTestEnv {
-    nodes: Arc<RwLock<Vec<NodeSlot>>>,
-    command_tx: mpsc::Sender<EnvironmentCommand>,
-    event_tx: broadcast::Sender<TestEvent>,
-    config: Arc<TangleTestConfig>,
-    initialized_tx: Option<oneshot::Sender<()>>,
-    running_nodes: Arc<AtomicUsize>,
+    pub nodes: Arc<RwLock<Vec<NodeSlot>>>,
+    pub command_tx: mpsc::Sender<EnvironmentCommand>,
+    pub event_tx: broadcast::Sender<TestEvent>,
+    pub config: Arc<TangleTestConfig>,
+    pub initialized_tx: Option<oneshot::Sender<()>>,
+    pub running_nodes: Arc<AtomicUsize>,
 }
 
 #[derive(Debug)]
-enum EnvironmentCommand {
+pub enum EnvironmentCommand {
     AddNode {
         node_id: usize,
         result_tx: oneshot::Sender<Result<(), Error>>,
@@ -387,14 +387,14 @@ impl Debug for NodeCommand {
 
 /// Represents a single node in the multi-node test environment
 pub struct NodeHandle {
-    node_id: usize,
-    addr: Multiaddr,
-    port: u16,
-    client: TangleClient,
-    signer: TanglePairSigner<sp_core::sr25519::Pair>,
-    state: Arc<RwLock<NodeState>>,
-    command_tx: mpsc::Sender<NodeCommand>,
-    test_env: Arc<RwLock<TangleTestEnv>>,
+    pub node_id: usize,
+    pub addr: Multiaddr,
+    pub port: u16,
+    pub client: TangleClient,
+    pub signer: TanglePairSigner<sp_core::sr25519::Pair>,
+    pub state: Arc<RwLock<NodeState>>,
+    pub command_tx: mpsc::Sender<NodeCommand>,
+    pub test_env: Arc<RwLock<TangleTestEnv>>,
 }
 
 impl NodeHandle {

--- a/crates/testing-utils/tangle/src/multi_node.rs
+++ b/crates/testing-utils/tangle/src/multi_node.rs
@@ -392,8 +392,8 @@ pub struct NodeHandle {
     pub port: u16,
     pub client: TangleClient,
     pub signer: TanglePairSigner<sp_core::sr25519::Pair>,
-    pub state: Arc<RwLock<NodeState>>,
-    pub command_tx: mpsc::Sender<NodeCommand>,
+    state: Arc<RwLock<NodeState>>,
+    command_tx: mpsc::Sender<NodeCommand>,
     pub test_env: Arc<RwLock<TangleTestEnv>>,
 }
 

--- a/crates/testing-utils/tangle/src/runner.rs
+++ b/crates/testing-utils/tangle/src/runner.rs
@@ -11,10 +11,10 @@ use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
 pub struct TangleTestEnv {
-    runner: TestRunner,
-    config: TangleConfig,
-    gadget_config: GadgetConfiguration,
-    runner_handle: Mutex<Option<JoinHandle<Result<(), Error>>>>,
+    pub runner: TestRunner,
+    pub config: TangleConfig,
+    pub gadget_config: GadgetConfiguration,
+    pub runner_handle: Mutex<Option<JoinHandle<Result<(), Error>>>>,
 }
 
 impl TangleTestEnv {


### PR DESCRIPTION
1. Adds tests for a blueprint_protocol p2p/gossip protocol. Completely honest protocol.
    1.  Generate random number
    2. Gossip
    3. Everyone sums it
    4. Everyone sends summation and verifies.
2. Makes test struct parameters public, we currently can't get keystore from a handle just the `TanglePairSigner<sr25519>` key which is restrictive.